### PR TITLE
feat(dto): implemented dto for corresponding entities

### DIFF
--- a/src/main/java/org/csps/backend/domain/dtos/response/AdminResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/AdminResponseDTO.java
@@ -1,0 +1,17 @@
+package org.csps.backend.domain.dtos.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminResponseDTO {
+    private String position;
+    private UserResponseDTO userResponseDTO;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/CartItemResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/CartItemResponseDTO.java
@@ -1,0 +1,17 @@
+package org.csps.backend.domain.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemResponseDTO {
+    private Long cartId;
+    private Long merchVariantId;
+    private int quantity;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/CartResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/CartResponseDTO.java
@@ -1,0 +1,18 @@
+package org.csps.backend.domain.dtos.response;
+
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartResponseDTO {
+    private String studentId;
+    private List<CartItemResponseDTO> cartItemResponseDTOs;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/MerchResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/MerchResponseDTO.java
@@ -1,0 +1,18 @@
+package org.csps.backend.domain.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MerchResponseDTO {
+    private Long merchId;
+    private String merchName;
+    private String description;
+    
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/MerchVariantResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/MerchVariantResponseDTO.java
@@ -1,0 +1,24 @@
+package org.csps.backend.domain.dtos.response;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MerchVariantResponseDTO {
+    private Long merchVariantId;
+    private String color;
+    private ClothingSizing size;
+    private Double price;
+    private Integer stockQuantity;
+
+    private Long merchId; // reference to MerchResponseDto (to avoid nesting)
+    
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/PurchaseItemResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/PurchaseItemResponseDTO.java
@@ -1,0 +1,17 @@
+package org.csps.backend.domain.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseItemResponseDTO {
+    private Long purchaseId;
+    private Long merchVariantId;
+    private int quantity;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/PurchaseResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/PurchaseResponseDTO.java
@@ -1,0 +1,25 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseResponseDTO {
+    private Long purchaseId;
+    private String studentId;
+    private Long purchaseItemId;
+    private List<PurchaseItemResponseDTO> items;
+    private LocalDateTime purchasedAt;
+    private Double totalPrice;
+    private Double receivedMoney;
+
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/StudentResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/StudentResponseDTO.java
@@ -1,0 +1,18 @@
+package org.csps.backend.domain.dtos.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StudentResponseDTO {
+    private String studentId;
+    private Byte yearLevel;
+    private UserResponseDTO userResponseDTO;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/UserResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/UserResponseDTO.java
@@ -1,0 +1,22 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponseDTO {
+    private Long userId;
+    private String firstName;
+    private String lastName;
+    private String middleName;
+    private LocalDate birthDate;
+    private String email;
+}

--- a/src/main/java/org/csps/backend/domain/entities/Admin.java
+++ b/src/main/java/org/csps/backend/domain/entities/Admin.java
@@ -1,11 +1,19 @@
 package org.csps.backend.domain.entities;
 
-import jakarta.persistence.*;
+import org.csps.backend.domain.enums.AdminPosition;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.csps.backend.domain.enums.AdminPosition;
 
 @Entity
 @Data
@@ -15,10 +23,11 @@ import org.csps.backend.domain.enums.AdminPosition;
 @Builder
 public class Admin {
 
-    @OneToOne
     @Id
-    @MapsId
-    @Column(name = "user_id")
+    private Long userId;
+
+    @OneToOne
+    @PrimaryKeyJoinColumn(name = "user_id")
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/csps/backend/domain/entities/Cart.java
+++ b/src/main/java/org/csps/backend/domain/entities/Cart.java
@@ -1,12 +1,19 @@
 package org.csps.backend.domain.entities;
 
-import jakarta.persistence.*;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrimaryKeyJoinColumn;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Entity
 @Table(name = "StudentCart")
@@ -17,11 +24,10 @@ import java.util.List;
 public class Cart {
 
     @Id
-    private String cartId; // same as studentId
+    private String cartId;
 
     @OneToOne
-    @MapsId  // tells JPA to use the same value as student_id for the primary key
-    @JoinColumn(name = "student_id") // FK and PK at the same time
+    @PrimaryKeyJoinColumn
     private Student student;
 
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)

--- a/src/main/java/org/csps/backend/domain/entities/User.java
+++ b/src/main/java/org/csps/backend/domain/entities/User.java
@@ -1,14 +1,22 @@
 package org.csps.backend.domain.entities;
 
-import jakarta.persistence.*;
+import java.util.Date;
+
+import org.csps.backend.domain.enums.UserRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.csps.backend.domain.enums.UserRole;
-
-import java.util.Date;
 
 @Entity
 @Table
@@ -21,7 +29,7 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
-
+    
     @Column(nullable = false)
     private String username;
 


### PR DESCRIPTION
Proposal of Idea: 

Idea
Introduce two new DTO folders for cleaner structure:
- base/ → shared minimal DTOs (common fields).
- summary/ → lightweight DTOs for list or dropdown views.

Reason
Avoids repeating the same fields in multiple DTOs.
Keeps request, response, base, and summary contexts clear.
Makes responses lighter when full details aren’t needed.
Easier to maintain as the project grows.

Example
UserBaseDTO → id, firstName, lastName
UserResponseDTO → UserBaseDTO + email, birthDate
UserSummaryDTO → id, fullName for lists