### PR TITLE
feat: add merch variant update endpoints with standardized API responses

### DIFF
--- a/src/main/java/org/csps/backend/controller/CartController.java
+++ b/src/main/java/org/csps/backend/controller/CartController.java
@@ -1,7 +1,9 @@
 package org.csps.backend.controller;
 
 import org.csps.backend.domain.dtos.response.CartResponseDTO;
+import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.service.CartService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,8 +23,9 @@ public class CartController {
     // Get cart by student ID
     @GetMapping("")
     @PreAuthorize("hasRole('STUDENT')")
-    public ResponseEntity<CartResponseDTO> getCart(@AuthenticationPrincipal String studentId) {
+    public ResponseEntity<GlobalResponseBuilder<CartResponseDTO>> getCart(@AuthenticationPrincipal String studentId) {
         CartResponseDTO cart = cartService.getCartByStudentId(studentId);
-        return ResponseEntity.ok(cart);
+        
+        return GlobalResponseBuilder.buildResponse("Cart retrieved successfully", cart, HttpStatus.OK);
     }
 }

--- a/src/main/java/org/csps/backend/controller/CartItemController.java
+++ b/src/main/java/org/csps/backend/controller/CartItemController.java
@@ -3,7 +3,9 @@ package org.csps.backend.controller;
 import org.csps.backend.domain.dtos.request.CartItemRequestDTO;
 import org.csps.backend.domain.dtos.request.RemoveCartItemRequestDTO;
 import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
+import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.service.CartItemService;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,22 +26,22 @@ public class CartItemController {
 
     @PostMapping
     @PreAuthorize("hasRole('STUDENT')")
-    public ResponseEntity<CartItemResponseDTO> addCartItem(@AuthenticationPrincipal String studentId, @RequestBody CartItemRequestDTO requestDTO) {
+    public ResponseEntity<GlobalResponseBuilder<CartItemResponseDTO>> addCartItem(@AuthenticationPrincipal String studentId, @RequestBody CartItemRequestDTO requestDTO) {
         // get student id from authentication
         requestDTO.setCartId(studentId);
 
         CartItemResponseDTO responseDTO = cartItemService.addCartItem(requestDTO);
-        return ResponseEntity.ok(responseDTO);
+        return GlobalResponseBuilder.buildResponse("Cart item added successfully", responseDTO, HttpStatus.CREATED);
     }
 
     @DeleteMapping
     @PreAuthorize("hasRole('STUDENT')")
-    public ResponseEntity<CartItemResponseDTO> removeCartItem(@AuthenticationPrincipal String studentId, @RequestBody RemoveCartItemRequestDTO requestDTO) {
+    public ResponseEntity<GlobalResponseBuilder<CartItemResponseDTO>> removeCartItem(@AuthenticationPrincipal String studentId, @RequestBody RemoveCartItemRequestDTO requestDTO) {
         // get student id from authentication
         requestDTO.setCartId(studentId);
 
         CartItemResponseDTO responseDTO = cartItemService.removeCartItem(requestDTO);
-        return ResponseEntity.ok(responseDTO);
+        return GlobalResponseBuilder.buildResponse("Cart item removed successfully", responseDTO, HttpStatus.OK);
     }
 
 }

--- a/src/main/java/org/csps/backend/controller/MerchVariantController.java
+++ b/src/main/java/org/csps/backend/controller/MerchVariantController.java
@@ -1,15 +1,19 @@
 package org.csps.backend.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.csps.backend.domain.dtos.request.MerchVariantRequestDTO;
+import org.csps.backend.domain.dtos.request.MerchVariantUpdateRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchVariantResponseDTO;
 import org.csps.backend.service.MerchVariantService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,5 +40,27 @@ public class MerchVariantController {
     public ResponseEntity<List<MerchVariantResponseDTO>> getMerchVariantByMerchId(@PathVariable Long merchId) {
         return ResponseEntity.ok(merchVariantService.getMerchVariantByMerchId(merchId));
     }
+
+    @GetMapping("/{merchId}/all")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('STUDENT')")
+    public ResponseEntity<List<MerchVariantResponseDTO>> getMerchVariantById(@PathVariable Long merchId) {
+        return ResponseEntity.ok(merchVariantService.getMerchVariantByMerchId(merchId));
+    }
+
+
+    @PutMapping("/{merchId}/update")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String,Object>> putMerchVariant(@PathVariable Long merchId, @RequestBody MerchVariantUpdateRequestDTO merchVariantUpdateRequestDTO) {
+        Map<String,Object> response = merchVariantService.putMerchVariant(merchId, merchVariantUpdateRequestDTO);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PatchMapping("/{merchId}/update")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Map<String,Object>> patchMerchVariant(@PathVariable Long merchId, @RequestBody MerchVariantUpdateRequestDTO merchVariantUpdateRequestDTO) {
+        Map<String,Object> response = merchVariantService.patchMerchVariant(merchId, merchVariantUpdateRequestDTO);
+        return ResponseEntity.ok(response);
+    }
+    
 }
 

--- a/src/main/java/org/csps/backend/domain/dtos/request/MerchVariantUpdateRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/MerchVariantUpdateRequestDTO.java
@@ -1,0 +1,14 @@
+package org.csps.backend.domain.dtos.request;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import lombok.Data;
+
+@Data
+public class MerchVariantUpdateRequestDTO {
+    private Long merchVariantId;
+    private String color;
+    private ClothingSizing size;
+    private Double price;
+    private Integer stockQuantity;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/GlobalResponseBuilder.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/GlobalResponseBuilder.java
@@ -1,0 +1,28 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import lombok.Data;
+
+@Data
+public class GlobalResponseBuilder<T> {
+    private String status;
+    private String message;
+    private T data;
+    private LocalDateTime timestamp;
+
+    
+    public static <T> ResponseEntity<GlobalResponseBuilder<T>> buildResponse(String message, T data, HttpStatus status) {
+        GlobalResponseBuilder<T> response = new GlobalResponseBuilder<>();
+        response.setStatus(status.name());
+        response.setMessage(message);
+        response.setData(data);
+        response.setTimestamp(LocalDateTime.now());
+
+        return ResponseEntity.status(status).body(response);
+    }
+
+}

--- a/src/main/java/org/csps/backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/csps/backend/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.csps.backend.domain.dtos.request.InvalidRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -158,5 +159,38 @@ public class GlobalExceptionHandler {
         error.put("path", request.getDescription(false));
 
         return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(MerchVariantNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleMerchVariantNotFoundException(MerchVariantNotFoundException ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.NOT_FOUND.value());
+        error.put("error", "Merch Variant Not Found");
+        error.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(InvalidRequestException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidRequestException(InvalidRequestException ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.BAD_REQUEST.value());
+        error.put("error", "Invalid Request");
+        error.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MerchVariantAlreadyExisted.class)
+    public ResponseEntity<Map<String, Object>> handleMerchVariantAlreadyExisted(MerchVariantAlreadyExisted ex) {
+        Map<String, Object> error = new HashMap<>();
+        error.put("timestamp", LocalDateTime.now());
+        error.put("status", HttpStatus.BAD_REQUEST.value());
+        error.put("error", "Merch Variant Already Existed");
+        error.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/org/csps/backend/exception/MerchVariantAlreadyExisted.java
+++ b/src/main/java/org/csps/backend/exception/MerchVariantAlreadyExisted.java
@@ -1,0 +1,8 @@
+package org.csps.backend.exception;
+
+public class MerchVariantAlreadyExisted extends RuntimeException {
+    public MerchVariantAlreadyExisted(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/csps/backend/repository/MerchVariantRepository.java
+++ b/src/main/java/org/csps/backend/repository/MerchVariantRepository.java
@@ -7,7 +7,6 @@ import org.csps.backend.domain.entities.MerchVariant;
 import org.csps.backend.domain.enums.ClothingSizing;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import java.util.List;
 
 @Repository
 public interface MerchVariantRepository extends  JpaRepository<MerchVariant, Long>{

--- a/src/main/java/org/csps/backend/service/MerchVariantService.java
+++ b/src/main/java/org/csps/backend/service/MerchVariantService.java
@@ -1,8 +1,10 @@
 package org.csps.backend.service;
 
 import java.util.List;
+import java.util.Map;
 
 import org.csps.backend.domain.dtos.request.MerchVariantRequestDTO;
+import org.csps.backend.domain.dtos.request.MerchVariantUpdateRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchVariantResponseDTO;
 
 public interface MerchVariantService {
@@ -11,4 +13,6 @@ public interface MerchVariantService {
     List<MerchVariantResponseDTO> addAllMerchVariant (List<MerchVariantRequestDTO> merchVariantRequests);
     List<MerchVariantResponseDTO> getAllMerchVariant();
     List<MerchVariantResponseDTO> getMerchVariantByMerchId(Long merchId);
+    Map<String, Object> putMerchVariant(Long merchId, MerchVariantUpdateRequestDTO merchVariantRequestDTO);
+    Map<String, Object> patchMerchVariant(Long merchId, MerchVariantUpdateRequestDTO merchVariantRequestDTO);
 }

--- a/src/main/java/org/csps/backend/service/impl/MerchVariantServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchVariantServiceImpl.java
@@ -1,11 +1,20 @@
 package org.csps.backend.service.impl;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
+import org.csps.backend.domain.dtos.request.InvalidRequestException;
 import org.csps.backend.domain.dtos.request.MerchVariantRequestDTO;
+import org.csps.backend.domain.dtos.request.MerchVariantUpdateRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchVariantResponseDTO;
 import org.csps.backend.domain.entities.Merch;
 import org.csps.backend.domain.entities.MerchVariant;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.MerchType;
+import org.csps.backend.exception.MerchNotFoundException;
+import org.csps.backend.exception.MerchVariantAlreadyExisted;
+import org.csps.backend.exception.MerchVariantNotFoundException;
 import org.csps.backend.mapper.MerchVariantMapper;
 import org.csps.backend.repository.MerchRepository;
 import org.csps.backend.repository.MerchVariantRepository;
@@ -85,4 +94,120 @@ public class MerchVariantServiceImpl implements MerchVariantService {
                 .map(merchVariantMapper::toResponseDTO)
                 .toList();
     }
+
+    @Override
+    public Map<String, Object> putMerchVariant(Long merchId, MerchVariantUpdateRequestDTO merchVariantRequestDTO) {
+        String color = merchVariantRequestDTO.getColor();
+        ClothingSizing clothingSizing = merchVariantRequestDTO.getSize();
+        Double price = merchVariantRequestDTO.getPrice();
+        Integer stockQuantity = merchVariantRequestDTO.getStockQuantity();
+
+        if (color.isEmpty() || clothingSizing == null || price == null || stockQuantity == null) {
+            throw new InvalidRequestException("Invalid Credential");
+        }
+        
+        Merch merch = merchRepository.findById(merchId)
+                      .orElseThrow(() -> new MerchNotFoundException("Merch Not Found"));
+
+        Long merchVariantId = merchVariantRequestDTO.getMerchVariantId();
+
+        MerchVariant merchVariant = merchVariantRepository.findById(merchVariantId)
+                .orElseThrow(() -> new MerchVariantNotFoundException("Merch Variant Not Found"));
+
+
+        MerchType merchType = merch.getMerchType();
+
+        boolean merchVariantAlreadyExisted = merchVariantRepository.existsByMerchAndColorAndSize(merch, color, clothingSizing);
+
+        if (merchVariantAlreadyExisted) {
+            throw new MerchVariantAlreadyExisted("Merch Variant Already Existed");
+        }
+
+        switch (merchType) {
+            case CLOTHING -> {
+                if (clothingSizing == null || price == null || stockQuantity == null) {
+                    throw new InvalidRequestException("Invalid Credential");
+                }
+
+            }
+            case PIN, STICKER, KEYCHAIN -> {
+                if (price == null || stockQuantity == null) {
+                    throw new InvalidRequestException("Invalid Credential");
+                }
+            }
+            default -> throw new InvalidRequestException("Invalid Credential");
+        }
+        
+        merchVariant.setColor(color);
+        merchVariant.setSize(clothingSizing);
+        merchVariant.setPrice(price);
+        merchVariant.setStockQuantity(stockQuantity);
+
+        merchVariantRepository.save(merchVariant);
+
+        return Map.of("message", "Merch Variant Updated Successfully",
+                        "timestamp", LocalDateTime.now(),
+                        "status", 200);
+
+        
+    }
+
+       @Override
+    public Map<String, Object> patchMerchVariant(Long merchId, MerchVariantUpdateRequestDTO merchVariantRequestDTO) {
+        String color = merchVariantRequestDTO.getColor();
+        ClothingSizing clothingSizing = merchVariantRequestDTO.getSize();
+        Double price = merchVariantRequestDTO.getPrice();
+        Integer stockQuantity = merchVariantRequestDTO.getStockQuantity();
+        
+        Merch merch = merchRepository.findById(merchId)
+                      .orElseThrow(() -> new MerchNotFoundException("Merch Not Found"));
+
+        Long merchVariantId = merchVariantRequestDTO.getMerchVariantId();
+
+        MerchVariant merchVariant = merchVariantRepository.findById(merchVariantId)
+                .orElseThrow(() -> new MerchVariantNotFoundException("Merch Variant Not Found"));
+
+
+        MerchType merchType = merch.getMerchType();
+
+        boolean merchVariantAlreadyExisted = merchVariantRepository.existsByMerchAndColorAndSize(merch, color, clothingSizing);
+
+        if (merchVariantAlreadyExisted) {
+            throw new MerchVariantAlreadyExisted("Merch Variant Already Existed");
+        }
+
+        switch (merchType) {
+            case CLOTHING -> {
+                if (clothingSizing == null || price == null || stockQuantity == null) {
+                    throw new InvalidRequestException("Invalid Credential");
+                }
+
+            }
+            case PIN, STICKER, KEYCHAIN -> {
+                if (clothingSizing != null) {
+                    throw new InvalidRequestException("Invalid Credential");
+                }
+                if (price == null || stockQuantity == null) {
+                    throw new InvalidRequestException("Invalid Credential");
+                }
+            }
+            default -> throw new InvalidRequestException("Invalid Credential");
+        }
+        
+        merchVariant.setColor(color);
+        merchVariant.setSize(clothingSizing);
+        merchVariant.setPrice(price);
+        merchVariant.setStockQuantity(stockQuantity);
+
+        merchVariantRepository.save(merchVariant);
+
+        return Map.of("message", "Merch Variant Updated Successfully",
+                        "timestamp", LocalDateTime.now(),
+                        "status", 200);
+
+        
+    }
+
+
+
 }


### PR DESCRIPTION
- Added PUT and PATCH endpoints for updating merch variants in the controller
- Implemented MerchVariantUpdateRequestDTO for request validation
- Added service layer methods for handling merch variant updates
- Added repository method existsByMerchAndColorAndSize for duplicate checks
- Introduced MerchVariantAlreadyExisted exception and exception handler
- Added GlobalResponseBuilder for standardized API responses
- Also implemented GlobalResponseBuilder for the Cart related Controllers.