### PR TITLE
feat: add ticket freebies flow and student profile completion fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-mail</artifactId>
 	</dependency>
@@ -66,11 +70,6 @@
 			<version>0.12.3</version>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>jakarta.validation</groupId>
-			<artifactId>jakarta.validation-api</artifactId>
-		</dependency>
-
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
@@ -150,6 +149,7 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<configuration>
+					<mainClass>org.csps.backend.BackendApplication</mainClass>
 					<excludes>
 						<exclude>
 							<groupId>org.projectlombok</groupId>

--- a/src/main/java/org/csps/backend/controller/AdminController.java
+++ b/src/main/java/org/csps/backend/controller/AdminController.java
@@ -62,6 +62,15 @@ public class AdminController {
         return GlobalResponseBuilder.buildResponse(message, adminResponseDTO, HttpStatus.OK);
     }
 
+    @PostMapping("/{adminId}/reset-password")
+    @PreAuthorize("hasRole('ADMIN_EXECUTIVE')")
+    @Auditable(action = AuditAction.UPDATE, resourceType = "Admin")
+    public ResponseEntity<GlobalResponseBuilder<AdminResponseDTO>> resetAdminPassword(@PathVariable Long adminId) {
+        AdminResponseDTO adminResponseDTO = adminService.resetAdminPassword(adminId);
+        String message = "Admin password reset to default successfully";
+        return GlobalResponseBuilder.buildResponse(message, adminResponseDTO, HttpStatus.OK);
+    }
+
     @PostMapping("/grant-access")
     @Auditable(action = AuditAction.CREATE, resourceType = "Admin")
     public ResponseEntity<GlobalResponseBuilder<AdminResponseDTO>> grantAdminAccess(

--- a/src/main/java/org/csps/backend/controller/AdminController.java
+++ b/src/main/java/org/csps/backend/controller/AdminController.java
@@ -72,6 +72,7 @@ public class AdminController {
     }
 
     @PostMapping("/grant-access")
+    @PreAuthorize("hasRole('ADMIN_EXECUTIVE')")
     @Auditable(action = AuditAction.CREATE, resourceType = "Admin")
     public ResponseEntity<GlobalResponseBuilder<AdminResponseDTO>> grantAdminAccess(
             @RequestParam String studentId,

--- a/src/main/java/org/csps/backend/controller/AuthController.java
+++ b/src/main/java/org/csps/backend/controller/AuthController.java
@@ -14,7 +14,6 @@ import org.csps.backend.domain.entities.UserAccount;
 import org.csps.backend.security.JwtService;
 import org.csps.backend.service.AdminService;
 import org.csps.backend.service.EmailVerificationService;
-import org.csps.backend.service.RefreshTokenService;
 import org.csps.backend.service.StudentService;
 import org.csps.backend.service.UserAccountService;
 import org.csps.backend.service.UserService;
@@ -42,8 +41,6 @@ public class AuthController {
     private final UserAccountService userAccountService;
     private final UserService userService;
     private final EmailVerificationService emailVerificationService; // Inject EmailVerificationService
-
-    private final RefreshTokenService refreshTokenService;
     private final JwtService jwtService;
     private final StudentService studentService;
     private final AdminService adminService;
@@ -83,18 +80,7 @@ public class AuthController {
 
     // logout
     @PostMapping("/logout")
-    public ResponseEntity<GlobalResponseBuilder<String>> logout(@RequestBody(required = false) Map<String, String> requestBody) {
-        String refreshToken = null;
-        if (requestBody != null && requestBody.containsKey("refreshToken")) {
-            refreshToken = requestBody.get("refreshToken");
-        }
-        
-        // Delete refresh token from database if it exists
-        if (refreshToken != null && !refreshToken.isBlank()) {
-            refreshTokenService.findByRefreshToken(refreshToken)
-                .ifPresent(refreshTokenService::deleteRefreshToken);
-        }
-        
+    public ResponseEntity<GlobalResponseBuilder<String>> logout() {
         return GlobalResponseBuilder.buildResponse(
             "Logout successful",
             null,
@@ -118,38 +104,6 @@ public class AuthController {
             null,
             HttpStatus.OK
         );
-    }
-
-    // refresh token
-    @PostMapping("/refresh")
-    public ResponseEntity<GlobalResponseBuilder<AuthResponseDTO>> refresh(
-        @RequestBody Map<String, String> requestBody
-    ) {
-        String requestToken = requestBody.get("refreshToken");
-        if (requestToken == null || requestToken.isBlank()) {
-            return GlobalResponseBuilder.buildResponse(
-                "Refresh token is missing",
-                null,
-                HttpStatus.BAD_REQUEST
-            );
-        }
-
-        var result = refreshTokenService.refreshAccessToken(requestToken);
-        if (result.isPresent()) {
-            String newAccessToken = result.get();
-            
-            return GlobalResponseBuilder.buildResponse(
-                "Access token refreshed successfully",
-                new AuthResponseDTO(newAccessToken),
-                HttpStatus.OK
-            );
-        } else {
-            return GlobalResponseBuilder.buildResponse(
-                "Invalid or expired refresh token",
-                null,
-                HttpStatus.UNAUTHORIZED
-            );
-        }
     }
 
     // get student profile

--- a/src/main/java/org/csps/backend/controller/CartItemController.java
+++ b/src/main/java/org/csps/backend/controller/CartItemController.java
@@ -3,6 +3,8 @@ package org.csps.backend.controller;
 import java.util.List;
 
 import org.csps.backend.domain.dtos.request.CartItemRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieSelectionRequestDTO;
+import org.csps.backend.domain.dtos.response.CartItemFreebieSelectionResponseDTO;
 import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.service.CartItemService;
@@ -30,9 +32,6 @@ public class CartItemController {
 
     private final CartItemService cartItemService;
 
-    /**
-     * Add item to cart.
-     */
     @PostMapping
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<CartItemResponseDTO>> addCartItem(
@@ -42,9 +41,6 @@ public class CartItemController {
         return GlobalResponseBuilder.buildResponse("Cart item added successfully", responseDTO, HttpStatus.CREATED);
     }
 
-    /**
-     * Get all items in cart.
-     */
     @GetMapping
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<List<CartItemResponseDTO>>> getCartItems(
@@ -53,9 +49,6 @@ public class CartItemController {
         return GlobalResponseBuilder.buildResponse("Cart items retrieved successfully", responseDTOs, HttpStatus.OK);
     }
 
-    /**
-     * Edit a cart item by updating its quantity.
-     */
     @PutMapping("/{merchVariantItemId}")
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<CartItemResponseDTO>> updateCartItemQuantity(
@@ -66,9 +59,30 @@ public class CartItemController {
         return GlobalResponseBuilder.buildResponse("Cart item updated successfully", responseDTO, HttpStatus.OK);
     }
 
-    /**
-     * Remove item from cart.
-     */
+    @GetMapping("/{merchVariantItemId}/freebie-selection")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ResponseEntity<GlobalResponseBuilder<CartItemFreebieSelectionResponseDTO>> getCartItemFreebieSelection(
+            @AuthenticationPrincipal String studentId,
+            @PathVariable Long merchVariantItemId) {
+        CartItemFreebieSelectionResponseDTO responseDTO = cartItemService.getCartItemFreebieSelection(
+                studentId,
+                merchVariantItemId);
+        return GlobalResponseBuilder.buildResponse("Cart freebie selection retrieved successfully", responseDTO, HttpStatus.OK);
+    }
+
+    @PutMapping("/{merchVariantItemId}/freebie-selection")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ResponseEntity<GlobalResponseBuilder<CartItemResponseDTO>> updateCartItemFreebieSelection(
+            @AuthenticationPrincipal String studentId,
+            @PathVariable Long merchVariantItemId,
+            @Valid @RequestBody List<TicketFreebieSelectionRequestDTO> requestDTO) {
+        CartItemResponseDTO responseDTO = cartItemService.updateCartItemFreebieSelection(
+                studentId,
+                merchVariantItemId,
+                requestDTO);
+        return GlobalResponseBuilder.buildResponse("Cart freebie selection updated successfully", responseDTO, HttpStatus.OK);
+    }
+
     @DeleteMapping("/{merchVariantItemId}")
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<Void>> removeCartItem(

--- a/src/main/java/org/csps/backend/controller/CartItemController.java
+++ b/src/main/java/org/csps/backend/controller/CartItemController.java
@@ -54,7 +54,7 @@ public class CartItemController {
     }
 
     /**
-     * Update cart item quantity.
+     * Edit a cart item by updating its quantity.
      */
     @PutMapping("/{merchVariantItemId}")
     @PreAuthorize("hasRole('STUDENT')")

--- a/src/main/java/org/csps/backend/controller/EventController.java
+++ b/src/main/java/org/csps/backend/controller/EventController.java
@@ -12,11 +12,13 @@ import org.csps.backend.domain.enums.AuditAction;
 import org.csps.backend.service.EventService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -49,6 +51,19 @@ public class EventController {
         String message = "Events retrieved successfully";
         return GlobalResponseBuilder.buildResponse(message, events, HttpStatus.OK);
     } 
+
+    @GetMapping("/search")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('STUDENT')")
+    public ResponseEntity<GlobalResponseBuilder<Page<EventResponseDTO>>> searchEvents(
+        @RequestParam String query,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+        @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+        @PageableDefault(size = 10, sort = "eventDate", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        Page<EventResponseDTO> results = eventService.searchEvent(query, startDate, endDate, pageable);
+        String message = "Events retrieved successfully";
+        return GlobalResponseBuilder.buildResponse(message, results, HttpStatus.OK);
+    }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN') or hasRole('STUDENT')")

--- a/src/main/java/org/csps/backend/controller/MerchController.java
+++ b/src/main/java/org/csps/backend/controller/MerchController.java
@@ -3,12 +3,15 @@ package org.csps.backend.controller;
 import java.io.IOException;
 import java.util.List;
 
+import org.csps.backend.annotation.Auditable;
 import org.csps.backend.domain.dtos.request.MerchRequestDTO;
 import org.csps.backend.domain.dtos.request.MerchUpdateRequestDTO;
 import org.csps.backend.domain.dtos.request.MerchVariantRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieConfigRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.MerchDetailedResponseDTO;
 import org.csps.backend.domain.dtos.response.MerchSummaryResponseDTO;
+import org.csps.backend.domain.enums.AuditAction;
 import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.service.MerchService;
 import org.springframework.data.domain.Page;
@@ -35,19 +38,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 @RestController
 @RequestMapping("/api/merch")
 @RequiredArgsConstructor
 public class MerchController {
 
     private final MerchService merchService;
+    private final ObjectMapper objectMapper;
 
     /**
-     * Creates a complete merchandise entry including all variants and items.
-     * Accepts multipart/form-data for image uploads (main image + variant images).
+     * Creates a merch item and, for tickets, optionally stores zero or many inline freebie configs.
      */
     @PostMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @PreAuthorize("hasRole('ADMIN')")
+    @Auditable(action = AuditAction.CREATE, resourceType = "Merch")
     public ResponseEntity<GlobalResponseBuilder<MerchDetailedResponseDTO>> createMerch(
             @RequestParam String merchName,
             @RequestParam String description,
@@ -56,26 +61,23 @@ public class MerchController {
             @RequestParam(required = false) String s3ImageKey,
             @RequestParam(required = true) MultipartFile merchImage,
             @RequestParam String variants,
-            @RequestParam(required = true) MultipartFile[] variantImages
+            @RequestParam(required = false) MultipartFile[] variantImages,
+            @RequestParam(required = false, defaultValue = "false") Boolean hasFreebie,
+            @RequestParam(required = false) String freebieConfigs
     ) throws IOException {
-        // Parse variants JSON to list
-        ObjectMapper mapper = new ObjectMapper();
-        List<MerchVariantRequestDTO> variantsList = mapper.readValue(
-            variants, 
+        List<MerchVariantRequestDTO> variantsList = objectMapper.readValue(
+            variants,
             new TypeReference<List<MerchVariantRequestDTO>>() {}
         );
-        
 
-
-        // Assign variant images to each variant
         if (variantImages != null) {
             for (int i = 0; i < variantsList.size() && i < variantImages.length; i++) {
                 variantsList.get(i).setVariantImage(variantImages[i]);
             }
         }
-      
 
-        // Build MerchRequestDTO
+        List<TicketFreebieConfigRequestDTO> parsedFreebieConfigs = parseFreebieConfigs(freebieConfigs);
+
         MerchRequestDTO request = MerchRequestDTO.builder()
                 .merchName(merchName)
                 .description(description)
@@ -83,14 +85,13 @@ public class MerchController {
                 .basePrice(basePrice)
                 .s3ImageKey(s3ImageKey)
                 .merchImage(merchImage)
+                .hasFreebie(hasFreebie)
+                .freebieConfigs(parsedFreebieConfigs)
                 .merchVariantRequestDto(variantsList)
                 .build();
 
-
-
         MerchDetailedResponseDTO createdMerch = merchService.createMerch(request);
-        String message = "Merchandise created successfully with all variants and items";
-        return GlobalResponseBuilder.buildResponse(message, createdMerch, HttpStatus.CREATED);
+        return GlobalResponseBuilder.buildResponse("Merchandise created successfully", createdMerch, HttpStatus.CREATED);
     }
 
     @GetMapping
@@ -119,28 +120,26 @@ public class MerchController {
 
     @PutMapping("/{merchId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Auditable(action = AuditAction.UPDATE, resourceType = "Merch")
     public ResponseEntity<GlobalResponseBuilder<MerchDetailedResponseDTO>> putMerch(
-            @PathVariable Long merchId, 
+            @PathVariable Long merchId,
             @Valid @RequestBody MerchUpdateRequestDTO request
     ) throws IOException {
         MerchDetailedResponseDTO response = merchService.putMerch(merchId, request);
-        return GlobalResponseBuilder.buildResponse("Merch Updated Successfully", response, HttpStatus.OK);
+        return GlobalResponseBuilder.buildResponse("Merch updated successfully", response, HttpStatus.OK);
     }
 
     @PatchMapping("/{merchId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Auditable(action = AuditAction.UPDATE, resourceType = "Merch")
     public ResponseEntity<GlobalResponseBuilder<MerchDetailedResponseDTO>> patchMerch(
-            @PathVariable Long merchId, 
+            @PathVariable Long merchId,
             @RequestBody MerchUpdateRequestDTO request
     ) throws IOException {
         MerchDetailedResponseDTO response = merchService.patchMerch(merchId, request);
-        return GlobalResponseBuilder.buildResponse("Merch Updated Successfully", response, HttpStatus.OK);
+        return GlobalResponseBuilder.buildResponse("Merch updated successfully", response, HttpStatus.OK);
     }
 
-    /**
-     * Deletes a merchandise entry and all its associated variants and items.
-     * Also deletes associated S3 images.
-     */
     @DeleteMapping("/{merchId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<Void>> deleteMerch(@PathVariable Long merchId) {
@@ -148,10 +147,6 @@ public class MerchController {
         return GlobalResponseBuilder.buildResponse("Merch archived successfully", null, HttpStatus.NO_CONTENT);
     }
 
-    /**
-     * Get archived merchandise with pagination and eager loading.
-     * Only fetches the size of the page requested.
-     */
     @GetMapping("/archive")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<Page<MerchDetailedResponseDTO>>> getArchivedMerch(
@@ -161,10 +156,6 @@ public class MerchController {
         return GlobalResponseBuilder.buildResponse("Retrieved archived merchandise", archived, HttpStatus.OK);
     }
 
-    /**
-     * Revert archived merchandise back to active status.
-     * Makes archived merchandise visible and available for purchase again.
-     */
     @PutMapping("/{merchId}/revert")
     @PreAuthorize("hasRole('ADMIN_EXECUTIVE') or hasRole('ADMIN_FINANCE')")
     public ResponseEntity<GlobalResponseBuilder<MerchDetailedResponseDTO>> revertMerch(@PathVariable Long merchId) {
@@ -172,4 +163,10 @@ public class MerchController {
         return GlobalResponseBuilder.buildResponse("Merchandise reverted to active status", reverted, HttpStatus.OK);
     }
 
+    private List<TicketFreebieConfigRequestDTO> parseFreebieConfigs(String freebieConfigs) throws IOException {
+        if (freebieConfigs == null || freebieConfigs.trim().isEmpty()) {
+            return List.of();
+        }
+        return objectMapper.readValue(freebieConfigs, new TypeReference<List<TicketFreebieConfigRequestDTO>>() {});
+    }
 }

--- a/src/main/java/org/csps/backend/controller/MerchCustomerController.java
+++ b/src/main/java/org/csps/backend/controller/MerchCustomerController.java
@@ -11,6 +11,7 @@ import org.csps.backend.service.MerchCustomerService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -53,9 +54,11 @@ public class MerchCustomerController {
     public ResponseEntity<Page<MerchCustomerResponseDTO>> getCustomersByMerchId(
             @PathVariable Long merchId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "7") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<MerchCustomerResponseDTO> customers = merchCustomerService.getCustomersByMerchId(merchId, pageable);
+            @RequestParam(defaultValue = "7") int size,
+            @RequestParam(defaultValue = "true") boolean includeFreebies
+            ) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "orderItemId"));
+        Page<MerchCustomerResponseDTO> customers = merchCustomerService.getCustomersByMerchId(merchId, pageable, includeFreebies);
         return ResponseEntity.ok(customers);
     }
 
@@ -75,9 +78,10 @@ public class MerchCustomerController {
             @PathVariable Long merchId,
             @RequestParam OrderStatus status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "7") int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        Page<MerchCustomerResponseDTO> customers = merchCustomerService.getCustomersByMerchIdAndStatus(merchId, status, pageable);
+            @RequestParam(defaultValue = "7") int size,
+            @RequestParam(defaultValue = "true") boolean includeFreebies) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "orderItemId"));
+        Page<MerchCustomerResponseDTO> customers = merchCustomerService.getCustomersByMerchIdAndStatus(merchId, status, pageable, includeFreebies);
         return ResponseEntity.ok(customers);
     }
 
@@ -90,8 +94,10 @@ public class MerchCustomerController {
      */
     @GetMapping("/{merchId}/count")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<Map<String, Long>> getCustomerCountByMerchId(@PathVariable Long merchId) {
-        long count = merchCustomerService.getCustomerCountByMerchId(merchId);
+    public ResponseEntity<Map<String, Long>> getCustomerCountByMerchId(
+            @PathVariable Long merchId,
+            @RequestParam(defaultValue = "true") boolean includeFreebies) {
+        long count = merchCustomerService.getCustomerCountByMerchId(merchId, includeFreebies);
         return ResponseEntity.ok(Map.of("count", count));
     }
 
@@ -136,8 +142,9 @@ public class MerchCustomerController {
     @GetMapping("/{merchId}/export")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<List<MerchCustomerResponseDTO>> exportCustomersByMerchId(
-            @PathVariable Long merchId) {
-        List<MerchCustomerResponseDTO> customers = merchCustomerService.getAllCustomersByMerchId(merchId);
+            @PathVariable Long merchId,
+            @RequestParam(defaultValue = "true") boolean includeFreebies) {
+        List<MerchCustomerResponseDTO> customers = merchCustomerService.getAllCustomersByMerchId(merchId, includeFreebies);
         return ResponseEntity.ok(customers);
     }
 }

--- a/src/main/java/org/csps/backend/controller/MerchVariantItemController.java
+++ b/src/main/java/org/csps/backend/controller/MerchVariantItemController.java
@@ -6,6 +6,7 @@ import org.csps.backend.annotation.Auditable;
 import org.csps.backend.domain.dtos.request.MerchVariantItemRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.MerchVariantItemResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
 import org.csps.backend.domain.enums.AuditAction;
 import org.csps.backend.domain.enums.ClothingSizing;
 import org.csps.backend.service.MerchVariantItemService;
@@ -69,6 +70,17 @@ public class MerchVariantItemController {
             @PathVariable Long id) {
         MerchVariantItemResponseDTO responseDTO = merchVariantItemService.getItemById(id);
         return GlobalResponseBuilder.buildResponse("Merch variant item retrieved successfully", responseDTO, HttpStatus.OK);
+    }
+
+    /**
+     * Get all freebies configured for the ticket owning this merch variant item.
+     */
+    @GetMapping("/{id}/freebies")
+    @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
+    public ResponseEntity<GlobalResponseBuilder<List<TicketFreebieConfigResponseDTO>>> getFreebiesByMerchVariantItemId(
+            @PathVariable Long id) {
+        List<TicketFreebieConfigResponseDTO> responseDTOs = merchVariantItemService.getFreebiesByMerchVariantItemId(id);
+        return GlobalResponseBuilder.buildResponse("Merch variant item freebies retrieved successfully", responseDTOs, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/org/csps/backend/controller/OrderController.java
+++ b/src/main/java/org/csps/backend/controller/OrderController.java
@@ -12,7 +12,9 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -78,8 +80,9 @@ public class OrderController {
     @GetMapping("/{orderId}")
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<OrderResponseDTO>> getOrderById(
-            @PathVariable Long orderId) {
-        OrderResponseDTO responseDTO = orderService.getOrderById(orderId);
+            @PathVariable Long orderId,
+            Authentication authentication) {
+        OrderResponseDTO responseDTO = orderService.getOrderById(orderId, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order retrieved successfully", responseDTO, HttpStatus.OK);
     }
 
@@ -107,8 +110,9 @@ public class OrderController {
     @PreAuthorize("hasRole('ADMIN') or hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<Page<OrderResponseDTO>>> searchOrders(
             @ModelAttribute OrderSearchDTO searchDTO,
+            Authentication authentication,
             @PageableDefault(size = 20, sort = "orderDate", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<OrderResponseDTO> results = orderService.searchOrders(searchDTO, pageable);
+        Page<OrderResponseDTO> results = orderService.searchOrders(searchDTO, pageable, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Orders retrieved successfully", results, HttpStatus.OK);
     }
 
@@ -122,5 +126,28 @@ public class OrderController {
             @PathVariable Long orderId) {
         orderService.deleteOrder(orderId);
         return GlobalResponseBuilder.buildResponse("Order deleted successfully", null, HttpStatus.NO_CONTENT);
+    }
+
+    /**
+     * Cancel a pending order owned by the authenticated student.
+     */
+    @PatchMapping("/{orderId}/cancel")
+    @PreAuthorize("hasRole('STUDENT')")
+    public ResponseEntity<GlobalResponseBuilder<OrderResponseDTO>> cancelOrder(
+            @AuthenticationPrincipal String studentId,
+            @PathVariable Long orderId) {
+        OrderResponseDTO responseDTO = orderService.cancelOrder(studentId, orderId);
+        return GlobalResponseBuilder.buildResponse("Order cancelled successfully", responseDTO, HttpStatus.OK);
+    }
+
+    private String resolveStudentScope(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+
+        boolean studentRequest = authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_STUDENT".equals(authority.getAuthority()));
+
+        return studentRequest ? String.valueOf(authentication.getPrincipal()) : null;
     }
 }

--- a/src/main/java/org/csps/backend/controller/OrderItemController.java
+++ b/src/main/java/org/csps/backend/controller/OrderItemController.java
@@ -2,11 +2,16 @@ package org.csps.backend.controller;
 
 import java.util.List;
 
+import org.csps.backend.annotation.Auditable;
 import org.csps.backend.domain.dtos.request.OrderItemRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieAssignmentRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.OrderItemResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO;
+import org.csps.backend.domain.enums.AuditAction;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.service.OrderItemService;
+import org.csps.backend.service.TicketFreebieAssignmentService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -20,6 +25,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,13 +38,10 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/order-items")
 @RequiredArgsConstructor
 public class OrderItemController {
-    
+
     private final OrderItemService orderItemService;
-    
-    /**
-     * Create a new order item.
-     * Only admins can create order items.
-     */
+    private final TicketFreebieAssignmentService ticketFreebieAssignmentService;
+
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<OrderItemResponseDTO>> createOrderItem(
@@ -46,10 +49,7 @@ public class OrderItemController {
         OrderItemResponseDTO responseDTO = orderItemService.createOrderItem(requestDTO);
         return GlobalResponseBuilder.buildResponse("Order item created successfully", responseDTO, HttpStatus.CREATED);
     }
-    
-    /**
-     * Get order item by ID.
-     */
+
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<OrderItemResponseDTO>> getOrderItemById(
@@ -58,10 +58,7 @@ public class OrderItemController {
         OrderItemResponseDTO responseDTO = orderItemService.getOrderItemById(id, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order item retrieved successfully", responseDTO, HttpStatus.OK);
     }
-    
-    /**
-     * Get all order items for a specific order.
-     */
+
     @GetMapping
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<List<OrderItemResponseDTO>>> getOrderItemsByOrderId(
@@ -70,11 +67,7 @@ public class OrderItemController {
         List<OrderItemResponseDTO> responseDTOs = orderItemService.getOrderItemsByOrderId(orderId, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", responseDTOs, HttpStatus.OK);
     }
-    
-    /**
-     * Get paginated order items for a specific order.
-     * Query params: orderId, page (0-indexed), size (default 20), sort (e.g., "createdAt,desc")
-     */
+
     @GetMapping("/paginated")
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<List<OrderItemResponseDTO>>> getOrderItemsByOrderIdPaginated(
@@ -84,11 +77,7 @@ public class OrderItemController {
         Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByOrderIdPaginated(orderId, pageable, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page.getContent(), HttpStatus.OK);
     }
-    
-    /**
-     * Get paginated order items by status.
-     * Query params: status, page (0-indexed), size (default 20), sort (e.g., "createdAt,desc")
-     */
+
     @GetMapping("/status")
     @PreAuthorize("hasRole('ADMIN') or hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<Page<OrderItemResponseDTO>>> getOrderItemsByStatus(
@@ -99,11 +88,6 @@ public class OrderItemController {
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page, HttpStatus.OK);
     }
 
-    /**
-     * Get all order items for the authenticated student (paginated).
-     * Query params: page (0-indexed), size (default 20), sort (e.g., "updatedAt,desc")
-     * IMPORTANT: This must come BEFORE /{orderId} to avoid route conflicts
-     */
     @GetMapping("/my-items")
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<Page<OrderItemResponseDTO>>> getMyOrderItems(
@@ -113,10 +97,6 @@ public class OrderItemController {
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page, HttpStatus.OK);
     }
 
-    /**
-     * Get all order items for the authenticated student with optional status filter (paginated).
-     * Query params: status (optional), page (0-indexed), size (default 20), sort (e.g., "updatedAt,desc")
-     */
     @GetMapping("/my-items/status")
     @PreAuthorize("hasRole('STUDENT')")
     public ResponseEntity<GlobalResponseBuilder<Page<OrderItemResponseDTO>>> getMyOrderItemsByStatus(
@@ -126,11 +106,7 @@ public class OrderItemController {
         Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByStudentIdAndStatusPaginated(studentId, status, pageable);
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page, HttpStatus.OK);
     }
-    
-    /**
-     * Update order item status.
-     * Only admins can update order item status.
-     */
+
     @PatchMapping("/{id}/status")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<OrderItemResponseDTO>> updateOrderItemStatus(
@@ -139,16 +115,34 @@ public class OrderItemController {
         OrderItemResponseDTO responseDTO = orderItemService.updateOrderItemStatus(id, status);
         return GlobalResponseBuilder.buildResponse("Order item status updated successfully", responseDTO, HttpStatus.OK);
     }
-    
-    /**
-     * Delete an order item.
-     * Only admins can delete order items.
-     */
+
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<Void>> deleteOrderItem(@PathVariable Long id) {
         orderItemService.deleteOrderItem(id);
         return GlobalResponseBuilder.buildResponse("Order item deleted successfully", null, HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/{orderItemId}/freebie-assignment")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('ADMIN_FINANCE') or hasRole('STUDENT')")
+    public ResponseEntity<GlobalResponseBuilder<List<TicketFreebieAssignmentResponseDTO>>> getOrderItemFreebieAssignment(
+            @PathVariable Long orderItemId,
+            Authentication authentication) {
+        String studentScope = resolveStudentScope(authentication);
+        List<TicketFreebieAssignmentResponseDTO> response = studentScope == null
+                ? ticketFreebieAssignmentService.getAssignmentsByOrderItemId(orderItemId)
+                : orderItemService.getOrderItemById(orderItemId, studentScope).getFreebieAssignments();
+        return GlobalResponseBuilder.buildResponse("Freebie assignment retrieved successfully", response, HttpStatus.OK);
+    }
+
+    @PutMapping("/{orderItemId}/freebie-assignment")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('ADMIN_FINANCE')")
+    @Auditable(action = AuditAction.UPDATE, resourceType = "TicketFreebieAssignment")
+    public ResponseEntity<GlobalResponseBuilder<List<TicketFreebieAssignmentResponseDTO>>> upsertOrderItemFreebieAssignment(
+            @PathVariable Long orderItemId,
+            @Valid @RequestBody List<TicketFreebieAssignmentRequestDTO> request) {
+        List<TicketFreebieAssignmentResponseDTO> response = ticketFreebieAssignmentService.upsertAssignments(orderItemId, request);
+        return GlobalResponseBuilder.buildResponse("Freebie assignment updated successfully", response, HttpStatus.OK);
     }
 
     private String resolveStudentScope(Authentication authentication) {

--- a/src/main/java/org/csps/backend/controller/OrderItemController.java
+++ b/src/main/java/org/csps/backend/controller/OrderItemController.java
@@ -13,6 +13,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,8 +53,9 @@ public class OrderItemController {
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<OrderItemResponseDTO>> getOrderItemById(
-            @PathVariable Long id) {
-        OrderItemResponseDTO responseDTO = orderItemService.getOrderItemById(id);
+            @PathVariable Long id,
+            Authentication authentication) {
+        OrderItemResponseDTO responseDTO = orderItemService.getOrderItemById(id, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order item retrieved successfully", responseDTO, HttpStatus.OK);
     }
     
@@ -63,8 +65,9 @@ public class OrderItemController {
     @GetMapping
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<List<OrderItemResponseDTO>>> getOrderItemsByOrderId(
-            @RequestParam Long orderId) {
-        List<OrderItemResponseDTO> responseDTOs = orderItemService.getOrderItemsByOrderId(orderId);
+            @RequestParam Long orderId,
+            Authentication authentication) {
+        List<OrderItemResponseDTO> responseDTOs = orderItemService.getOrderItemsByOrderId(orderId, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", responseDTOs, HttpStatus.OK);
     }
     
@@ -76,8 +79,9 @@ public class OrderItemController {
     @PreAuthorize("hasRole('STUDENT') or hasRole('ADMIN')")
     public ResponseEntity<GlobalResponseBuilder<List<OrderItemResponseDTO>>> getOrderItemsByOrderIdPaginated(
             @RequestParam Long orderId,
+            Authentication authentication,
             Pageable pageable) {
-        Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByOrderIdPaginated(orderId, pageable);
+        Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByOrderIdPaginated(orderId, pageable, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page.getContent(), HttpStatus.OK);
     }
     
@@ -90,8 +94,8 @@ public class OrderItemController {
     public ResponseEntity<GlobalResponseBuilder<Page<OrderItemResponseDTO>>> getOrderItemsByStatus(
             @RequestParam OrderStatus status,
             @PageableDefault(size = 5) Pageable pageable,
-            @AuthenticationPrincipal String studentId) {
-        Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByStatus(status, pageable, studentId);
+            Authentication authentication) {
+        Page<OrderItemResponseDTO> page = orderItemService.getOrderItemsByStatus(status, pageable, resolveStudentScope(authentication));
         return GlobalResponseBuilder.buildResponse("Order items retrieved successfully", page, HttpStatus.OK);
     }
 
@@ -145,5 +149,16 @@ public class OrderItemController {
     public ResponseEntity<GlobalResponseBuilder<Void>> deleteOrderItem(@PathVariable Long id) {
         orderItemService.deleteOrderItem(id);
         return GlobalResponseBuilder.buildResponse("Order item deleted successfully", null, HttpStatus.NO_CONTENT);
+    }
+
+    private String resolveStudentScope(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+
+        boolean studentRequest = authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_STUDENT".equals(authority.getAuthority()));
+
+        return studentRequest ? String.valueOf(authentication.getPrincipal()) : null;
     }
 }

--- a/src/main/java/org/csps/backend/controller/RecoveryTokenController.java
+++ b/src/main/java/org/csps/backend/controller/RecoveryTokenController.java
@@ -1,16 +1,15 @@
 package org.csps.backend.controller;
 
+import java.util.Map;
+
 import org.csps.backend.domain.dtos.request.PasswordRecoveryRequestDTO;
 import org.csps.backend.domain.dtos.request.PasswordResetRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.RecoveryTokenResponseDTO;
-import org.csps.backend.domain.entities.RecoveryToken;
-import org.csps.backend.domain.entities.UserAccount;
 import org.csps.backend.mapper.RecoveryTokenMapper;
 import org.csps.backend.service.RecoveryTokenService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,24 +27,16 @@ public class RecoveryTokenController {
 
     private final RecoveryTokenService recoveryTokenService;
     private final RecoveryTokenMapper recoveryTokenMapper;
-    private final PasswordEncoder passwordEncoder;
 
-    /**
-     * Request password recovery - sends recovery token via email
-     * User must have verified email to request recovery
-     */
     @PostMapping("/request")
     public ResponseEntity<GlobalResponseBuilder<RecoveryTokenResponseDTO>> requestRecovery(
             @Valid @RequestBody PasswordRecoveryRequestDTO requestDTO) {
-        
+
         try {
-            /* generate recovery token */
-            RecoveryToken recoveryToken = recoveryTokenService.generateRecoveryToken(requestDTO);
-            
-            RecoveryTokenResponseDTO responseDTO = recoveryTokenMapper.toResponseDTO(recoveryToken);
+            recoveryTokenService.generateRecoveryToken(requestDTO);
             return GlobalResponseBuilder.buildResponse(
                 "Recovery token sent to email",
-                responseDTO,
+                null,
                 HttpStatus.OK
             );
         } catch (org.csps.backend.exception.ResourceNotFoundException e) {
@@ -64,13 +55,10 @@ public class RecoveryTokenController {
         }
     }
 
-    /**
-     * Validate recovery token - check if token is valid and not expired
-     */
     @PostMapping("/validate")
     public ResponseEntity<GlobalResponseBuilder<RecoveryTokenResponseDTO>> validateToken(
-            @RequestBody java.util.Map<String, String> request) {
-        
+            @RequestBody Map<String, String> request) {
+
         try {
             String token = request.get("token");
             if (token == null || token.isBlank()) {
@@ -80,11 +68,9 @@ public class RecoveryTokenController {
                     HttpStatus.BAD_REQUEST
                 );
             }
-            
-            /* validate token */
-            RecoveryToken recoveryToken = recoveryTokenService.validateRecoveryToken(token);
-            
-            RecoveryTokenResponseDTO responseDTO = recoveryTokenMapper.toResponseDTO(recoveryToken);
+
+            RecoveryTokenResponseDTO responseDTO = recoveryTokenMapper.toResponseDTO(
+                    recoveryTokenService.validateRecoveryToken(token));
             return GlobalResponseBuilder.buildResponse(
                 "Recovery token is valid",
                 responseDTO,
@@ -105,15 +91,11 @@ public class RecoveryTokenController {
         }
     }
 
-    /**
-     * Reset password using recovery token
-     */
     @PostMapping("/reset-password")
     public ResponseEntity<GlobalResponseBuilder<String>> resetPassword(
             @Valid @RequestBody PasswordResetRequestDTO requestDTO) {
-        
+
         try {
-            /* check if passwords match */
             if (!requestDTO.getNewPassword().equals(requestDTO.getConfirmPassword())) {
                 return GlobalResponseBuilder.buildResponse(
                     "Passwords do not match",
@@ -121,30 +103,9 @@ public class RecoveryTokenController {
                     HttpStatus.BAD_REQUEST
                 );
             }
-            
-            /* validate recovery token */
-            RecoveryToken recoveryToken = recoveryTokenService.validateRecoveryToken(requestDTO.getToken());
-            
-            /* check if token already used */
-            if (recoveryToken.getIsUsed()) {
-                return GlobalResponseBuilder.buildResponse(
-                    "Recovery token has already been used",
-                    null,
-                    HttpStatus.BAD_REQUEST
-                );
-            }
-            
-            /* reset password */
-            UserAccount userAccount = recoveryToken.getUserAccount();
-            
-            String encodedPassword = passwordEncoder.encode(requestDTO.getNewPassword());
-            userAccount.setPassword(encodedPassword);
-            
-            /* mark token as used */
-            recoveryTokenService.markTokenAsUsed(requestDTO.getToken());
-            
-            log.info("password reset successfully for user: {}", userAccount.getUserAccountId());
-            
+
+            recoveryTokenService.resetPassword(requestDTO.getToken(), requestDTO.getNewPassword());
+
             return GlobalResponseBuilder.buildResponse(
                 "Password reset successfully",
                 null,
@@ -171,6 +132,4 @@ public class RecoveryTokenController {
             );
         }
     }
-
- 
 }

--- a/src/main/java/org/csps/backend/controller/SalesController.java
+++ b/src/main/java/org/csps/backend/controller/SalesController.java
@@ -9,6 +9,7 @@ import org.csps.backend.service.SalesService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -45,7 +46,10 @@ public class SalesController {
             @RequestParam(defaultValue = "6") int size,
             @ModelAttribute OrderSearchDTO search) {
         
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(
+            page,
+            size,
+            Sort.by(Sort.Direction.DESC, "orderDate").and(Sort.by(Sort.Direction.DESC, "orderId")));
         Page<TransactionDTO> transactions = salesService.getTransactions(pageable, search);
         return GlobalResponseBuilder.buildResponse("Transactions retrieved successfully", transactions, HttpStatus.OK);
     }

--- a/src/main/java/org/csps/backend/controller/StudentController.java
+++ b/src/main/java/org/csps/backend/controller/StudentController.java
@@ -5,6 +5,7 @@ import org.csps.backend.domain.dtos.request.UserRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.StudentResponseDTO;
 import org.csps.backend.service.StudentService;
+import org.csps.backend.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -30,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class StudentController {
 
    private final StudentService studentService;
+   private final UserService userService;
 
    @PostMapping()
    @PreAuthorize("hasRole('ADMIN_EXECUTIVE')")
@@ -40,7 +43,7 @@ public class StudentController {
    }
 
    @GetMapping()
-   @PreAuthorize("hasRole('ADMIN')")
+   @PreAuthorize("hasAnyRole('ADMIN_EXECUTIVE')")
    public ResponseEntity<Page<StudentResponseDTO>> getAllStudents(
            @RequestParam(defaultValue = "0") int page,
            @RequestParam(defaultValue = "7") int size,
@@ -59,11 +62,21 @@ public class StudentController {
    }
 
    @GetMapping("/{studentId}")
-   @PreAuthorize("hasRole('ADMIN')")
+   @PreAuthorize("hasAnyRole('ADMIN_EXECUTIVE')")
    public ResponseEntity<StudentResponseDTO> getStudent(@PathVariable String studentId) {
        // should be map first to responseDTO
        StudentResponseDTO student = studentService.getStudentProfile(studentId);
        return ResponseEntity.ok(student);
+   }
+
+   @PatchMapping("/{studentId}/restore-default-password")
+   @PreAuthorize("hasRole('ADMIN_EXECUTIVE')")
+   public ResponseEntity<GlobalResponseBuilder<String>> restoreDefaultPassword(@PathVariable String studentId) {
+       userService.restoreStudentPassword(studentId);
+       return GlobalResponseBuilder.buildResponse(
+               "Default password restored successfully",
+               "Password reset to the default student format",
+               HttpStatus.OK);
    }
 
    @PutMapping("/{studentId}/complete-profile")

--- a/src/main/java/org/csps/backend/controller/StudentController.java
+++ b/src/main/java/org/csps/backend/controller/StudentController.java
@@ -1,7 +1,7 @@
 package org.csps.backend.controller;
 
+import org.csps.backend.domain.dtos.request.StudentProfileCompletionRequestDTO;
 import org.csps.backend.domain.dtos.request.StudentRequestDTO;
-import org.csps.backend.domain.dtos.request.UserRequestDTO;
 import org.csps.backend.domain.dtos.response.GlobalResponseBuilder;
 import org.csps.backend.domain.dtos.response.StudentResponseDTO;
 import org.csps.backend.service.StudentService;
@@ -83,9 +83,9 @@ public class StudentController {
    @PreAuthorize("hasRole('STUDENT')")
    public ResponseEntity<GlobalResponseBuilder<StudentResponseDTO>> completeProfile(
            @PathVariable String studentId,
-           @Valid @RequestBody UserRequestDTO userRequestDTO) {
+           @Valid @RequestBody StudentProfileCompletionRequestDTO profileRequestDTO) {
        
-       StudentResponseDTO updated = studentService.completeStudentProfile(studentId, userRequestDTO);
+       StudentResponseDTO updated = studentService.completeStudentProfile(studentId, profileRequestDTO);
        String message = "Profile completed successfully";
        return GlobalResponseBuilder.buildResponse(message, updated, HttpStatus.OK);
    }

--- a/src/main/java/org/csps/backend/domain/dtos/request/CartItemRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/CartItemRequestDTO.java
@@ -1,5 +1,9 @@
 package org.csps.backend.domain.dtos.request;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,4 +16,8 @@ import lombok.NoArgsConstructor;
 public class CartItemRequestDTO {
     private Long merchVariantItemId;
     private int quantity;
+
+    @Valid
+    @Builder.Default
+    private List<TicketFreebieSelectionRequestDTO> freebieSelections = new ArrayList<>();
 }

--- a/src/main/java/org/csps/backend/domain/dtos/request/MerchRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/MerchRequestDTO.java
@@ -24,14 +24,13 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class MerchRequestDTO {
-    
     @NotBlank(message = "Merchandise name is required")
     @Size(max = 100, message = "Merchandise name must not exceed 100 characters")
     private String merchName;
-    
+
     @Size(max = 500, message = "Description must not exceed 500 characters")
     private String description;
-    
+
     @NotNull(message = "Merchandise type is required")
     private MerchType merchType;
 
@@ -39,13 +38,20 @@ public class MerchRequestDTO {
     @Positive
     private Double basePrice;
 
-    private String s3ImageKey; // Placeholder key; actual image will be uploaded separately
+    private String s3ImageKey;
 
     @JsonIgnore
-    private MultipartFile merchImage; // Image file for the merch
+    private MultipartFile merchImage;
 
-    
+    @Builder.Default
+    private Boolean hasFreebie = false;
+
+    @Valid
+    @Builder.Default
+    private List<TicketFreebieConfigRequestDTO> freebieConfigs = new ArrayList<>();
+
     @JsonProperty("variants")
     @Valid
+    @Builder.Default
     private List<MerchVariantRequestDTO> merchVariantRequestDto = new ArrayList<>();
 }

--- a/src/main/java/org/csps/backend/domain/dtos/request/MerchUpdateRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/MerchUpdateRequestDTO.java
@@ -1,12 +1,27 @@
 package org.csps.backend.domain.dtos.request;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.csps.backend.domain.enums.MerchType;
 
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class MerchUpdateRequestDTO {
     private String merchName;
     private String description;
     private MerchType merchType;
+    private Boolean hasFreebie;
+
+    @Valid
+    @Builder.Default
+    private List<TicketFreebieConfigRequestDTO> freebieConfigs = new ArrayList<>();
 }

--- a/src/main/java/org/csps/backend/domain/dtos/request/OrderItemRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/OrderItemRequestDTO.java
@@ -29,7 +29,5 @@ public class OrderItemRequestDTO {
 
     private OrderStatus orderStatus;
     
-    @NotNull(message = "Price at purchase is required")
-    @Min(value = 0, message = "Price must be non-negative")
     private Double priceAtPurchase;
 }

--- a/src/main/java/org/csps/backend/domain/dtos/request/OrderItemRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/OrderItemRequestDTO.java
@@ -1,7 +1,11 @@
 package org.csps.backend.domain.dtos.request;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.csps.backend.domain.enums.OrderStatus;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -14,20 +18,26 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class OrderItemRequestDTO {
-    
-    @NotNull(message = "Order ID is required")
     private Long orderId;
-    
+
     private Long merchVariantId;
 
     @NotNull(message = "MerchVariantItem ID is required")
     private Long merchVariantItemId;
-    
+
     @Min(value = 1, message = "Quantity must be at least 1")
     @NotNull(message = "Quantity is required")
     private Integer quantity;
 
     private OrderStatus orderStatus;
-    
+
     private Double priceAtPurchase;
+
+    @Valid
+    @Builder.Default
+    private List<TicketFreebieSelectionRequestDTO> freebieSelections = new ArrayList<>();
+
+    @Valid
+    @Builder.Default
+    private List<TicketFreebieAssignmentRequestDTO> freebieAssignments = new ArrayList<>();
 }

--- a/src/main/java/org/csps/backend/domain/dtos/request/OrderSearchDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/OrderSearchDTO.java
@@ -18,6 +18,8 @@ public class OrderSearchDTO {
     private String studentId;
     
     private String status;
+
+    private Integer year;
     
     private LocalDateTime startDate;
     

--- a/src/main/java/org/csps/backend/domain/dtos/request/StudentProfileCompletionRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/StudentProfileCompletionRequestDTO.java
@@ -1,0 +1,31 @@
+package org.csps.backend.domain.dtos.request;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StudentProfileCompletionRequestDTO {
+
+    @Size(max = 50, message = "Middle name must not exceed 50 characters")
+    private String middleName;
+
+    @NotNull(message = "Birth date is required")
+    @Past(message = "Birth date must be in the past")
+    private LocalDate birthDate;
+
+    @NotBlank(message = "Email is required")
+    @Email(message = "Invalid email format")
+    private String email;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieAssignmentRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieAssignmentRequestDTO.java
@@ -1,0 +1,24 @@
+package org.csps.backend.domain.dtos.request;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieFulfillmentStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TicketFreebieAssignmentRequestDTO {
+    private Long ticketFreebieConfigId;
+    private ClothingSizing selectedSize;
+
+    private String selectedColor;
+
+    private String selectedDesign;
+
+    private TicketFreebieFulfillmentStatus fulfillmentStatus;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieConfigRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieConfigRequestDTO.java
@@ -1,0 +1,37 @@
+package org.csps.backend.domain.dtos.request;
+
+import java.util.List;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TicketFreebieConfigRequestDTO {
+    private Long ticketFreebieConfigId;
+
+    @NotNull(message = "Freebie category is required")
+    private TicketFreebieCategory category;
+
+    @NotBlank(message = "Freebie name is required")
+    private String freebieName;
+
+    private Integer displayOrder;
+
+    private String clothingSubtype;
+
+    private List<ClothingSizing> sizes;
+
+    private List<String> colors;
+
+    private List<String> designs;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieSelectionRequestDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/request/TicketFreebieSelectionRequestDTO.java
@@ -1,0 +1,19 @@
+package org.csps.backend.domain.dtos.request;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TicketFreebieSelectionRequestDTO {
+    private Long ticketFreebieConfigId;
+    private ClothingSizing selectedSize;
+    private String selectedColor;
+    private String selectedDesign;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/AuthResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/AuthResponseDTO.java
@@ -11,7 +11,4 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AuthResponseDTO {
     private String accessToken;
-
-
-
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/CartItemFreebieSelectionItemResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/CartItemFreebieSelectionItemResponseDTO.java
@@ -1,0 +1,32 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.util.List;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CartItemFreebieSelectionItemResponseDTO {
+    private Long ticketFreebieConfigId;
+    private Integer displayOrder;
+    private TicketFreebieCategory category;
+    private String freebieName;
+    private String clothingSubtype;
+    private List<ClothingSizing> availableSizes;
+    private List<String> availableColors;
+    private List<String> availableDesigns;
+    private ClothingSizing selectedSize;
+    private String selectedColor;
+    private String selectedDesign;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/CartItemFreebieSelectionResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/CartItemFreebieSelectionResponseDTO.java
@@ -1,0 +1,21 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CartItemFreebieSelectionResponseDTO {
+    private Long merchVariantItemId;
+    private Long merchId;
+    private List<CartItemFreebieSelectionItemResponseDTO> freebies;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/CartItemResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/CartItemResponseDTO.java
@@ -1,5 +1,7 @@
 package org.csps.backend.domain.dtos.response;
 
+import java.util.List;
+
 import org.csps.backend.domain.enums.MerchType;
 
 import lombok.AllArgsConstructor;
@@ -7,21 +9,21 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class CartItemResponseDTO {
-    private Long merchVariantItemId; // Specific SKU ID
+    private Long merchVariantItemId;
     private String merchName;
-    private String size;             // e.g., "M" (Null if not clothing)
-    private String color;            
-    private String design;           
-    private String s3ImageKey;       // Variant-specific image
-    private Double unitPrice;        // Current price
+    private String size;
+    private String color;
+    private String design;
+    private String s3ImageKey;
+    private Double unitPrice;
     private int quantity;
-    private Double subTotal;         // unitPrice * quantity
-
+    private Double subTotal;
     private MerchType merchType;
+    private Boolean hasFreebie;
+    private List<CartItemFreebieSelectionItemResponseDTO> freebieSelections;
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/MerchCustomerResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/MerchCustomerResponseDTO.java
@@ -1,59 +1,37 @@
 package org.csps.backend.domain.dtos.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.csps.backend.domain.enums.ClothingSizing;
 import org.csps.backend.domain.enums.OrderStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/**
- * Response DTO representing a customer who purchased a specific merch.
- * Combines student profile information with order details for admin views.
- *
- * @field studentId      the student's unique 8-character ID
- * @field studentName    full name (firstName + lastName) from UserProfile
- * @field yearLevel      the student's current year level
- * @field merchName      the name of the purchased merch
- * @field color          the variant color (nullable for non-clothing)
- * @field design         the variant design
- * @field size           the item size (nullable for non-clothing)
- * @field quantity       the number of items purchased
- * @field totalPrice     quantity * priceAtPurchase
- * @field orderStatus    current status of the order item (PENDING, CLAIMED, etc.)
- * @field orderDate      when the order was placed
- * @field s3ImageKey     S3 key for the variant image
- */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MerchCustomerResponseDTO {
-
+    private Long orderItemId;
     private String studentId;
-
     private String studentName;
-
     private Byte yearLevel;
-
     private String merchName;
-
     private String color;
-
     private String design;
-
     private ClothingSizing size;
-
     private Integer quantity;
-
     private Double totalPrice;
-
     private OrderStatus orderStatus;
-
     private LocalDateTime orderDate;
-
     private String s3ImageKey;
+    private Boolean hasFreebie;
+    private List<TicketFreebieAssignmentResponseDTO> freebieAssignments;
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/MerchDetailedResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/MerchDetailedResponseDTO.java
@@ -5,28 +5,30 @@ import java.util.List;
 import org.csps.backend.domain.enums.MerchType;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MerchDetailedResponseDTO {
     private Long merchId;
     private String merchName;
-
     private String description;
     private MerchType merchType;
-
     private Double basePrice;
-    
     private String s3ImageKey;
+    private Boolean hasFreebie;
+    private List<TicketFreebieConfigResponseDTO> freebieConfigs;
+    private Boolean purchaseBlocked;
+    private String purchaseBlockMessage;
 
     @JsonAlias("variants")
-    private List<MerchVariantResponseDTO> variants; // include variants here
+    private List<MerchVariantResponseDTO> variants;
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/MerchSummaryResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/MerchSummaryResponseDTO.java
@@ -1,6 +1,10 @@
 package org.csps.backend.domain.dtos.response;
 
+import java.util.List;
+
 import org.csps.backend.domain.enums.MerchType;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,6 +15,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MerchSummaryResponseDTO {
     private Long merchId;
     private String merchName;
@@ -19,4 +24,20 @@ public class MerchSummaryResponseDTO {
     private Double basePrice;
     private String s3ImageKey;
     private Integer totalStockQuantity;
+    private Boolean hasFreebie;
+    private List<TicketFreebieConfigResponseDTO> freebieConfigs;
+    private Boolean purchaseBlocked;
+    private String purchaseBlockMessage;
+
+    public MerchSummaryResponseDTO(Long merchId, String merchName, String description, MerchType merchType,
+            Double basePrice, String s3ImageKey, Integer totalStockQuantity, Boolean hasFreebie) {
+        this.merchId = merchId;
+        this.merchName = merchName;
+        this.description = description;
+        this.merchType = merchType;
+        this.basePrice = basePrice;
+        this.s3ImageKey = s3ImageKey;
+        this.totalStockQuantity = totalStockQuantity;
+        this.hasFreebie = hasFreebie;
+    }
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/OrderItemResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/OrderItemResponseDTO.java
@@ -1,11 +1,10 @@
 package org.csps.backend.domain.dtos.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.domain.enums.OrderStatus;
-
-import com.fasterxml.jackson.annotation.JsonAlias;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,34 +16,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class OrderItemResponseDTO {
-    
     private Long orderItemId;
-    
     private Long orderId;
-    
     private String studentId;
-    
     private String studentName;
-    
     private String merchName;
-    
     private String color;
-    
     private String design;
-    
     private String size;
-        
     private Integer quantity;
-        
     private Double totalPrice;
-
     private OrderStatus orderStatus;
-    
     private String s3ImageKey;
-
     private MerchType merchType;
-    
+    private List<TicketFreebieAssignmentResponseDTO> freebieAssignments;
     private LocalDateTime createdAt;
-        
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/org/csps/backend/domain/dtos/response/RecoveryTokenResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/RecoveryTokenResponseDTO.java
@@ -18,9 +18,7 @@ public class RecoveryTokenResponseDTO {
     private Long recoveryTokenId;
     
     private Long userAccountId;
-    
-    private String token;
-    
+
     private LocalDateTime createdAt;
     
     @JsonAlias("expiresAt")

--- a/src/main/java/org/csps/backend/domain/dtos/response/TicketFreebieAssignmentResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/TicketFreebieAssignmentResponseDTO.java
@@ -1,0 +1,41 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+import org.csps.backend.domain.enums.TicketFreebieFulfillmentStatus;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TicketFreebieAssignmentResponseDTO {
+    private Long ticketFreebieAssignmentId;
+    private Long orderItemId;
+    private Long ticketFreebieConfigId;
+    private Boolean hasFreebie;
+    private TicketFreebieCategory category;
+    private String freebieName;
+    private String clothingSubtype;
+    private List<ClothingSizing> allowedSizes;
+    private List<String> allowedColors;
+    private List<String> allowedDesigns;
+    private ClothingSizing selectedSize;
+    private String selectedColor;
+    private String selectedDesign;
+    private TicketFreebieFulfillmentStatus fulfillmentStatus;
+    private LocalDateTime claimedAt;
+    private LocalDateTime fulfilledAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/TicketFreebieConfigResponseDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/TicketFreebieConfigResponseDTO.java
@@ -1,0 +1,29 @@
+package org.csps.backend.domain.dtos.response;
+
+import java.util.List;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TicketFreebieConfigResponseDTO {
+    private Long ticketFreebieConfigId;
+    private Integer displayOrder;
+    private TicketFreebieCategory category;
+    private String freebieName;
+    private String clothingSubtype;
+    private List<ClothingSizing> sizes;
+    private List<String> colors;
+    private List<String> designs;
+}

--- a/src/main/java/org/csps/backend/domain/dtos/response/sales/TransactionDTO.java
+++ b/src/main/java/org/csps/backend/domain/dtos/response/sales/TransactionDTO.java
@@ -20,5 +20,5 @@ public class TransactionDTO {
     private String membershipType; // e.g., "Non-Member", "Member"
     private BigDecimal amount;
     private String date;           // ISO 8601 or formatted date string
-    private String status;         // "PAID", "PENDING", "REJECTED"
+    private String status;         // "PENDING", "CLAIMED", "REJECTED", "CANCELLED"
 }

--- a/src/main/java/org/csps/backend/domain/entities/CartItem.java
+++ b/src/main/java/org/csps/backend/domain/entities/CartItem.java
@@ -1,12 +1,26 @@
 package org.csps.backend.domain.entities;
 
-import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.csps.backend.domain.entities.composites.CartItemId;
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.csps.backend.domain.entities.composites.CartItemId;
-
 
 @Entity
 @Table(name = "cart_item")
@@ -17,18 +31,31 @@ import org.csps.backend.domain.entities.composites.CartItemId;
 public class CartItem {
 
     @EmbeddedId
-    private CartItemId id;
+    private CartItemId cartItemId;
 
     @ManyToOne
-    @MapsId("cartId")   // FK + PK
+    @MapsId("cartId")
     @JoinColumn(name = "student_id", nullable = false)
     private Cart cart;
 
     @ManyToOne
-    @MapsId("merchVariantItemId") // Change this to the Item (SKU)
+    @MapsId("merchVariantItemId")
     @JoinColumn(name = "merch_variant_item_id", nullable = false)
     private MerchVariantItem merchVariantItem;
 
     private int quantity;
-}
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private ClothingSizing selectedFreebieSize;
+
+    @Column(nullable = true)
+    private String selectedFreebieColor;
+
+    @Column(nullable = true)
+    private String selectedFreebieDesign;
+
+    @OneToMany(mappedBy = "cartItem", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<CartItemFreebieSelection> freebieSelections = new ArrayList<>();
+}

--- a/src/main/java/org/csps/backend/domain/entities/CartItemFreebieSelection.java
+++ b/src/main/java/org/csps/backend/domain/entities/CartItemFreebieSelection.java
@@ -1,0 +1,64 @@
+package org.csps.backend.domain.entities;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "cart_item_freebie_selection",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_cart_item_freebie_selection_cart_config", columnNames = {"student_id", "merch_variant_item_id", "ticket_freebie_config_id"})
+    },
+    indexes = {
+        @Index(name = "idx_cart_item_freebie_selection_cart", columnList = "student_id, merch_variant_item_id"),
+        @Index(name = "idx_cart_item_freebie_selection_config", columnList = "ticket_freebie_config_id")
+    }
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CartItemFreebieSelection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cartItemFreebieSelectionId;
+
+    @ManyToOne
+    @JoinColumns({
+        @JoinColumn(name = "student_id", referencedColumnName = "student_id", nullable = false),
+        @JoinColumn(name = "merch_variant_item_id", referencedColumnName = "merch_variant_item_id", nullable = false)
+    })
+    private CartItem cartItem;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_freebie_config_id", nullable = false)
+    private TicketFreebieConfig ticketFreebieConfig;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private ClothingSizing selectedSize;
+
+    @Column(nullable = true)
+    private String selectedColor;
+
+    @Column(nullable = true)
+    private String selectedDesign;
+}

--- a/src/main/java/org/csps/backend/domain/entities/Merch.java
+++ b/src/main/java/org/csps/backend/domain/entities/Merch.java
@@ -31,7 +31,7 @@ public class Merch {
     @Column(nullable = false)
     private String merchName;
 
-    @Column(nullable = false, length=1000)
+    @Column(nullable = false, length = 1000)
     private String description;
 
     @Enumerated(EnumType.STRING)
@@ -42,11 +42,15 @@ public class Merch {
     private Double basePrice;
 
     @Column(nullable = false)
-    private String s3ImageKey;  // S3 object key of the first variant's image - REQUIRED
+    private String s3ImageKey;
 
     @Column(nullable = false)
     @Builder.Default
-    private Boolean isActive = true;  // soft delete flag
+    private Boolean isActive = true;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Boolean hasFreebie = false;
 
     @OneToMany(mappedBy = "merch", cascade = CascadeType.ALL, orphanRemoval = true)
     @Fetch(FetchMode.SUBSELECT)

--- a/src/main/java/org/csps/backend/domain/entities/Merch.java
+++ b/src/main/java/org/csps/backend/domain/entities/Merch.java
@@ -31,7 +31,7 @@ public class Merch {
     @Column(nullable = false)
     private String merchName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length=1000)
     private String description;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/org/csps/backend/domain/entities/MerchVariant.java
+++ b/src/main/java/org/csps/backend/domain/entities/MerchVariant.java
@@ -64,5 +64,5 @@ public class MerchVariant {
 
     @Column(nullable = false)
     private String s3ImageKey;  // S3 object key - REQUIRED, every variant must have an image
-    
+
 }

--- a/src/main/java/org/csps/backend/domain/entities/OrderItem.java
+++ b/src/main/java/org/csps/backend/domain/entities/OrderItem.java
@@ -63,7 +63,9 @@ public class OrderItem {
     @PrePersist
     protected void onCreate() {
         this.updatedAt = LocalDateTime.now();
-        this.orderStatus = OrderStatus.PENDING;
+        if (this.orderStatus == null) {
+            this.orderStatus = OrderStatus.PENDING;
+        }
     }
 
 }

--- a/src/main/java/org/csps/backend/domain/entities/RefreshToken.java
+++ b/src/main/java/org/csps/backend/domain/entities/RefreshToken.java
@@ -34,9 +34,13 @@ public class RefreshToken {
     private UserAccount userAccount;
 
     @PrePersist
-    public void setExpiryDate() {
+    public void initializeExpiryDate() {
         if (expiryDate == null) {
-            expiryDate = Instant.now().plus(Duration.ofDays(7)); 
+            refreshExpiryDate();
         }
+    }
+
+    public void refreshExpiryDate() {
+        expiryDate = Instant.now().plus(Duration.ofDays(7));
     }
 }

--- a/src/main/java/org/csps/backend/domain/entities/TicketFreebieAssignment.java
+++ b/src/main/java/org/csps/backend/domain/entities/TicketFreebieAssignment.java
@@ -1,0 +1,81 @@
+package org.csps.backend.domain.entities;
+
+import java.time.LocalDateTime;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.TicketFreebieFulfillmentStatus;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "ticket_freebie_assignment",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ticket_freebie_assignment_order_item_config", columnNames = {"order_item_id", "ticket_freebie_config_id"})
+    },
+    indexes = {
+        @Index(name = "idx_ticket_freebie_assignment_order_item", columnList = "order_item_id"),
+        @Index(name = "idx_ticket_freebie_assignment_config", columnList = "ticket_freebie_config_id"),
+        @Index(name = "idx_ticket_freebie_assignment_status", columnList = "fulfillment_status")
+    }
+)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketFreebieAssignment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketFreebieAssignmentId;
+
+    @ManyToOne
+    @JoinColumn(name = "order_item_id", nullable = false)
+    private OrderItem orderItem;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_freebie_config_id", nullable = false)
+    private TicketFreebieConfig ticketFreebieConfig;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = true)
+    private ClothingSizing selectedSize;
+
+    @Column(nullable = true)
+    private String selectedColor;
+
+    @Column(nullable = true)
+    private String selectedDesign;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fulfillment_status", nullable = false)
+    private TicketFreebieFulfillmentStatus fulfillmentStatus;
+
+    @Column(nullable = true)
+    private LocalDateTime claimedAt;
+
+    @Column(nullable = true)
+    private LocalDateTime fulfilledAt;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/csps/backend/domain/entities/TicketFreebieColorOption.java
+++ b/src/main/java/org/csps/backend/domain/entities/TicketFreebieColorOption.java
@@ -1,0 +1,43 @@
+package org.csps.backend.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "ticket_freebie_color_option",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ticket_freebie_color_option", columnNames = {"ticket_freebie_config_id", "color_label"})
+    },
+    indexes = {
+        @Index(name = "idx_ticket_freebie_color_option_config", columnList = "ticket_freebie_config_id")
+    }
+)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketFreebieColorOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketFreebieColorOptionId;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_freebie_config_id", nullable = false)
+    private TicketFreebieConfig ticketFreebieConfig;
+
+    @Column(name = "color_label", nullable = false)
+    private String colorLabel;
+}

--- a/src/main/java/org/csps/backend/domain/entities/TicketFreebieConfig.java
+++ b/src/main/java/org/csps/backend/domain/entities/TicketFreebieConfig.java
@@ -1,0 +1,80 @@
+package org.csps.backend.domain.entities;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "ticket_freebie_config",
+    indexes = {
+        @Index(name = "idx_ticket_freebie_config_ticket_merch", columnList = "ticket_merch_id")
+    }
+)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketFreebieConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketFreebieConfigId;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_merch_id", nullable = false)
+    private Merch ticketMerch;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer displayOrder = 0;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TicketFreebieCategory category;
+
+    @Column(nullable = false)
+    private String freebieName;
+
+    @Column(nullable = true)
+    private String clothingSubtype;
+
+    @OneToMany(mappedBy = "ticketFreebieConfig", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<TicketFreebieSizeOption> sizeOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ticketFreebieConfig", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<TicketFreebieColorOption> colorOptions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "ticketFreebieConfig", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<TicketFreebieDesignOption> designOptions = new ArrayList<>();
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/org/csps/backend/domain/entities/TicketFreebieDesignOption.java
+++ b/src/main/java/org/csps/backend/domain/entities/TicketFreebieDesignOption.java
@@ -1,0 +1,43 @@
+package org.csps.backend.domain.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "ticket_freebie_design_option",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ticket_freebie_design_option", columnNames = {"ticket_freebie_config_id", "design_label"})
+    },
+    indexes = {
+        @Index(name = "idx_ticket_freebie_design_option_config", columnList = "ticket_freebie_config_id")
+    }
+)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketFreebieDesignOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketFreebieDesignOptionId;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_freebie_config_id", nullable = false)
+    private TicketFreebieConfig ticketFreebieConfig;
+
+    @Column(name = "design_label", nullable = false)
+    private String designLabel;
+}

--- a/src/main/java/org/csps/backend/domain/entities/TicketFreebieSizeOption.java
+++ b/src/main/java/org/csps/backend/domain/entities/TicketFreebieSizeOption.java
@@ -1,0 +1,48 @@
+package org.csps.backend.domain.entities;
+
+import org.csps.backend.domain.enums.ClothingSizing;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "ticket_freebie_size_option",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ticket_freebie_size_option", columnNames = {"ticket_freebie_config_id", "size_label"})
+    },
+    indexes = {
+        @Index(name = "idx_ticket_freebie_size_option_config", columnList = "ticket_freebie_config_id")
+    }
+)
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TicketFreebieSizeOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long ticketFreebieSizeOptionId;
+
+    @ManyToOne
+    @JoinColumn(name = "ticket_freebie_config_id", nullable = false)
+    private TicketFreebieConfig ticketFreebieConfig;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "size_label", nullable = false)
+    private ClothingSizing sizeLabel;
+}

--- a/src/main/java/org/csps/backend/domain/enums/OrderStatus.java
+++ b/src/main/java/org/csps/backend/domain/enums/OrderStatus.java
@@ -5,5 +5,6 @@ public enum OrderStatus {
     TO_BE_CLAIMED,
     PENDING,
     CLAIMED,
-    REJECTED
+    REJECTED,
+    CANCELLED
 }

--- a/src/main/java/org/csps/backend/domain/enums/TicketFreebieCategory.java
+++ b/src/main/java/org/csps/backend/domain/enums/TicketFreebieCategory.java
@@ -1,0 +1,6 @@
+package org.csps.backend.domain.enums;
+
+public enum TicketFreebieCategory {
+    CLOTHING,
+    NON_CLOTHING
+}

--- a/src/main/java/org/csps/backend/domain/enums/TicketFreebieFulfillmentStatus.java
+++ b/src/main/java/org/csps/backend/domain/enums/TicketFreebieFulfillmentStatus.java
@@ -1,0 +1,9 @@
+package org.csps.backend.domain.enums;
+
+public enum TicketFreebieFulfillmentStatus {
+    NO_FREEBIE,
+    PENDING_DETAILS,
+    DETAILS_COMPLETED,
+    CLAIMED,
+    FULFILLED
+}

--- a/src/main/java/org/csps/backend/mapper/CartItemMapper.java
+++ b/src/main/java/org/csps/backend/mapper/CartItemMapper.java
@@ -19,11 +19,17 @@ public interface CartItemMapper {
     @Mapping(source = "quantity", target = "quantity")
     @Mapping(source = "merchVariantItem.merchVariant.merch.merchType", target = "merchType")
     @Mapping(target = "subTotal", expression = "java(cartItem.getQuantity() * (cartItem.getMerchVariantItem() != null ? cartItem.getMerchVariantItem().getPrice() : 0.0))")
+    @Mapping(target = "hasFreebie", ignore = true)
+    @Mapping(target = "freebieSelections", ignore = true)
     CartItemResponseDTO toResponseDTO(CartItem cartItem);
 
-    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "cartItemId", ignore = true)
     @Mapping(target = "cart", ignore = true)
     @Mapping(target = "merchVariantItem", ignore = true)
+    @Mapping(target = "selectedFreebieSize", ignore = true)
+    @Mapping(target = "selectedFreebieColor", ignore = true)
+    @Mapping(target = "selectedFreebieDesign", ignore = true)
+    @Mapping(target = "freebieSelections", ignore = true)
     @Mapping(source = "quantity", target = "quantity")
     CartItem toEntity(CartItemRequestDTO cartItemRequestDTO);
 }

--- a/src/main/java/org/csps/backend/mapper/MerchMapper.java
+++ b/src/main/java/org/csps/backend/mapper/MerchMapper.java
@@ -4,18 +4,38 @@ import org.csps.backend.domain.dtos.request.MerchRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchDetailedResponseDTO;
 import org.csps.backend.domain.dtos.response.MerchSummaryResponseDTO;
 import org.csps.backend.domain.entities.Merch;
+import org.csps.backend.domain.entities.MerchVariant;
+import org.csps.backend.domain.entities.MerchVariantItem;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring", uses = {MerchVariantMapper.class})
 public interface MerchMapper {
-    // Entity -> DTO
     @Mapping(target = "variants", source = "merchVariantList")
-    MerchDetailedResponseDTO toDetailedResponseDTO (Merch merch);
+    @Mapping(target = "freebieConfigs", ignore = true)
+    @Mapping(target = "purchaseBlocked", ignore = true)
+    @Mapping(target = "purchaseBlockMessage", ignore = true)
+    MerchDetailedResponseDTO toDetailedResponseDTO(Merch merch);
 
-    
+    @Mapping(target = "freebieConfigs", ignore = true)
+    @Mapping(target = "purchaseBlocked", ignore = true)
+    @Mapping(target = "purchaseBlockMessage", ignore = true)
+    @Mapping(target = "totalStockQuantity", expression = "java(getTotalStockQuantity(merch))")
+    MerchSummaryResponseDTO toSummaryResponseDTO(Merch merch);
 
-    // DTO -> Entity
     @Mapping(target = "merchVariantList", source = "merchVariantRequestDto")
     Merch toEntity(MerchRequestDTO dto);
+
+    default Integer getTotalStockQuantity(Merch merch) {
+        if (merch == null || merch.getMerchVariantList() == null) {
+            return 0;
+        }
+        return merch.getMerchVariantList().stream()
+            .map(MerchVariant::getMerchVariantItems)
+            .filter(items -> items != null)
+            .flatMap(java.util.List::stream)
+            .map(MerchVariantItem::getStockQuantity)
+            .filter(stock -> stock != null)
+            .reduce(0, Integer::sum);
+    }
 }

--- a/src/main/java/org/csps/backend/mapper/OrderItemMapper.java
+++ b/src/main/java/org/csps/backend/mapper/OrderItemMapper.java
@@ -20,6 +20,7 @@ public interface OrderItemMapper {
     @Mapping(source = "merchVariantItem.merchVariant.s3ImageKey", target = "s3ImageKey")
     @Mapping(source = "quantity", target = "quantity")
     @Mapping(target = "totalPrice", expression = "java(orderItem.getQuantity() * orderItem.getPriceAtPurchase())")
+    @Mapping(target = "freebieAssignments", ignore = true)
     @Mapping(source = "createdAt", target = "createdAt")
     @Mapping(source = "updatedAt", target = "updatedAt")
     @Mapping(source="orderStatus", target="orderStatus")

--- a/src/main/java/org/csps/backend/mapper/TicketFreebieAssignmentMapper.java
+++ b/src/main/java/org/csps/backend/mapper/TicketFreebieAssignmentMapper.java
@@ -1,0 +1,21 @@
+package org.csps.backend.mapper;
+
+import org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO;
+import org.csps.backend.domain.entities.TicketFreebieAssignment;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TicketFreebieAssignmentMapper {
+    @Mapping(source = "ticketFreebieAssignmentId", target = "ticketFreebieAssignmentId")
+    @Mapping(source = "orderItem.orderItemId", target = "orderItemId")
+    @Mapping(source = "ticketFreebieConfig.ticketFreebieConfigId", target = "ticketFreebieConfigId")
+    @Mapping(target = "hasFreebie", ignore = true)
+    @Mapping(target = "category", ignore = true)
+    @Mapping(target = "freebieName", ignore = true)
+    @Mapping(target = "clothingSubtype", ignore = true)
+    @Mapping(target = "allowedSizes", ignore = true)
+    @Mapping(target = "allowedColors", ignore = true)
+    @Mapping(target = "allowedDesigns", ignore = true)
+    TicketFreebieAssignmentResponseDTO toResponseDTO(TicketFreebieAssignment assignment);
+}

--- a/src/main/java/org/csps/backend/mapper/TicketFreebieConfigMapper.java
+++ b/src/main/java/org/csps/backend/mapper/TicketFreebieConfigMapper.java
@@ -1,0 +1,15 @@
+package org.csps.backend.mapper;
+
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
+import org.csps.backend.domain.entities.TicketFreebieConfig;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TicketFreebieConfigMapper {
+    @Mapping(source = "displayOrder", target = "displayOrder")
+    @Mapping(target = "sizes", expression = "java(config.getSizeOptions().stream().map(option -> option.getSizeLabel()).toList())")
+    @Mapping(target = "colors", expression = "java(config.getColorOptions().stream().map(option -> option.getColorLabel()).toList())")
+    @Mapping(target = "designs", expression = "java(config.getDesignOptions().stream().map(option -> option.getDesignLabel()).toList())")
+    TicketFreebieConfigResponseDTO toResponseDTO(TicketFreebieConfig config);
+}

--- a/src/main/java/org/csps/backend/repository/CartItemFreebieSelectionRepository.java
+++ b/src/main/java/org/csps/backend/repository/CartItemFreebieSelectionRepository.java
@@ -1,0 +1,25 @@
+package org.csps.backend.repository;
+
+import java.util.List;
+
+import org.csps.backend.domain.entities.CartItemFreebieSelection;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CartItemFreebieSelectionRepository extends JpaRepository<CartItemFreebieSelection, Long> {
+    List<CartItemFreebieSelection> findByCartItemCartCartIdAndCartItemMerchVariantItemMerchVariantItemId(
+            String cartId,
+            Long merchVariantItemId);
+
+    boolean existsByTicketFreebieConfigTicketMerchMerchId(Long merchId);
+
+    long countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedSize(Long configId, ClothingSizing selectedSize);
+
+    long countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedColorIgnoreCase(Long configId, String selectedColor);
+
+    long countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedDesignIgnoreCase(Long configId, String selectedDesign);
+
+    void deleteByCartItemCartCartIdAndCartItemMerchVariantItemMerchVariantItemId(String cartId, Long merchVariantItemId);
+}

--- a/src/main/java/org/csps/backend/repository/CartItemRepository.java
+++ b/src/main/java/org/csps/backend/repository/CartItemRepository.java
@@ -1,5 +1,8 @@
 package org.csps.backend.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.csps.backend.domain.entities.CartItem;
 import org.csps.backend.domain.entities.composites.CartItemId;
 import org.csps.backend.domain.enums.MerchType;
@@ -9,12 +12,27 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CartItemRepository extends JpaRepository<CartItem, CartItemId>{
-    
+public interface CartItemRepository extends JpaRepository<CartItem, CartItemId> {
+
     @Query("SELECT COUNT(ci) > 0 FROM CartItem ci " +
            "JOIN ci.merchVariantItem mvi " +
            "JOIN mvi.merchVariant mv " +
            "JOIN mv.merch m " +
            "WHERE ci.cart.student.studentId = :studentId AND m.merchType = :merchType")
     boolean existsByStudentIdAndMerchType(@Param("studentId") String studentId, @Param("merchType") MerchType merchType);
+
+    @Query("SELECT COUNT(ci) > 0 FROM CartItem ci " +
+           "JOIN ci.merchVariantItem mvi " +
+           "JOIN mvi.merchVariant mv " +
+           "JOIN mv.merch m " +
+           "WHERE ci.cart.student.studentId = :studentId AND m.merchId = :merchId")
+    boolean existsByStudentIdAndMerchId(@Param("studentId") String studentId, @Param("merchId") Long merchId);
+
+    List<CartItem> findByCartCartId(String cartId);
+
+    Optional<CartItem> findByCartCartIdAndMerchVariantItemMerchVariantItemId(String cartId, Long merchVariantItemId);
+
+    boolean existsByMerchVariantItemMerchVariantItemId(Long merchVariantItemId);
+
+    boolean existsByMerchVariantItemMerchVariantMerchVariantId(Long merchVariantId);
 }

--- a/src/main/java/org/csps/backend/repository/MerchRepository.java
+++ b/src/main/java/org/csps/backend/repository/MerchRepository.java
@@ -45,13 +45,14 @@ public interface MerchRepository extends JpaRepository<Merch, Long>{
             m.merchType, 
             m.basePrice, 
             m.s3ImageKey, 
-            CAST(SUM(i.stockQuantity) AS int)
+            CAST(COALESCE(SUM(i.stockQuantity), 0) AS int),
+            m.hasFreebie
         )
         FROM Merch m
         LEFT JOIN m.merchVariantList v
         LEFT JOIN v.merchVariantItems i
         WHERE m.isActive = true
-        GROUP BY m.merchId
+        GROUP BY m.merchId, m.merchName, m.description, m.merchType, m.basePrice, m.s3ImageKey, m.hasFreebie
     """)
     List<MerchSummaryResponseDTO> findAllSummaries();
 
@@ -63,13 +64,14 @@ public interface MerchRepository extends JpaRepository<Merch, Long>{
             m.merchType, 
             m.basePrice, 
             m.s3ImageKey, 
-            CAST(COALESCE(SUM(i.stockQuantity), 0) AS int)
+            CAST(COALESCE(SUM(i.stockQuantity), 0) AS int),
+            m.hasFreebie
         )
         FROM Merch m
         LEFT JOIN m.merchVariantList v
         LEFT JOIN v.merchVariantItems i
         WHERE m.merchType = :type AND m.isActive = true
-        GROUP BY m.merchId, m.merchName, m.description, m.merchType, m.basePrice, m.s3ImageKey
+        GROUP BY m.merchId, m.merchName, m.description, m.merchType, m.basePrice, m.s3ImageKey, m.hasFreebie
     """)
     List<MerchSummaryResponseDTO> findAllSummaryByType(@Param("type") MerchType type);
 }

--- a/src/main/java/org/csps/backend/repository/MerchVariantItemRepository.java
+++ b/src/main/java/org/csps/backend/repository/MerchVariantItemRepository.java
@@ -49,4 +49,5 @@ public interface MerchVariantItemRepository extends JpaRepository<MerchVariantIt
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT mvi FROM MerchVariantItem mvi WHERE mvi.merchVariantItemId = :id")
     Optional<MerchVariantItem> findByIdWithLock(Long id);
+
 }

--- a/src/main/java/org/csps/backend/repository/OrderItemRepository.java
+++ b/src/main/java/org/csps/backend/repository/OrderItemRepository.java
@@ -1,6 +1,7 @@
 package org.csps.backend.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.csps.backend.domain.entities.OrderItem;
 import org.csps.backend.domain.enums.MerchType;
@@ -18,12 +19,24 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     List<OrderItem> findByOrderOrderId(Long orderId);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    Optional<OrderItem> findByOrderItemIdAndOrderStudentStudentId(Long orderItemId, String studentId);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    List<OrderItem> findByOrderOrderIdAndOrderStudentStudentId(Long orderId, String studentId);
     
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<OrderItem> findByOrderOrderId(Long orderId, Pageable pageable);
 
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    Page<OrderItem> findByOrderOrderIdAndOrderStudentStudentId(Long orderId, String studentId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<OrderItem> findByOrderStatusAndOrderStudentStudentId(OrderStatus status, String studentId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    Page<OrderItem> findByOrderStatusOrderByUpdatedAtDesc(OrderStatus status, Pageable pageable);
     
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<OrderItem> findByOrderStudentStudentIdOrderByUpdatedAtDesc(String studentId, Pageable pageable);
@@ -38,7 +51,7 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     /* eagerly load order item with student profile and merch details for notifications */
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     @Query("SELECT oi FROM OrderItem oi WHERE oi.orderItemId = :id")
-    java.util.Optional<OrderItem> findByIdWithStudentAndMerchDetails(@Param("id") Long id);
+    Optional<OrderItem> findByIdWithStudentAndMerchDetails(@Param("id") Long id);
 
     /**
      * Find all order items for a specific merch (paginated) with eager loading.

--- a/src/main/java/org/csps/backend/repository/OrderItemRepository.java
+++ b/src/main/java/org/csps/backend/repository/OrderItemRepository.java
@@ -47,11 +47,19 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     /* eager load related entities to prevent N+1 queries in dashboard */
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     List<OrderItem> findTop5ByOrderStatusInOrderByCreatedAtDesc(List<OrderStatus> statuses);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    List<OrderItem> findTop5ByOrderStatusInAndMerchVariantItemMerchVariantMerchMerchTypeNotOrderByCreatedAtDesc(
+            List<OrderStatus> statuses,
+            MerchType merchType);
     
     /* eagerly load order item with student profile and merch details for notifications */
     @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     @Query("SELECT oi FROM OrderItem oi WHERE oi.orderItemId = :id")
     Optional<OrderItem> findByIdWithStudentAndMerchDetails(@Param("id") Long id);
+
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    List<OrderItem> findByOrderItemIdIn(List<Long> orderItemIds);
 
     /**
      * Find all order items for a specific merch (paginated) with eager loading.
@@ -78,6 +86,10 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
     @Query("SELECT oi FROM OrderItem oi WHERE oi.merchVariantItem.merchVariant.merch.merchId = :merchId AND oi.orderStatus = :status")
     Page<OrderItem> findByMerchIdAndOrderStatus(@Param("merchId") Long merchId, @Param("status") OrderStatus status, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"order", "order.student", "order.student.userAccount", "order.student.userAccount.userProfile", "merchVariantItem", "merchVariantItem.merchVariant", "merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    @Query("SELECT oi FROM OrderItem oi WHERE oi.merchVariantItem.merchVariant.merch.merchId = :merchId AND oi.orderStatus = :status")
+    List<OrderItem> findAllByMerchIdAndOrderStatus(@Param("merchId") Long merchId, @Param("status") OrderStatus status);
+
     /**
      * Check if a student has any order items of a given merch type with a specific status.
      * Used to check if MEMBERSHIP merch is already in a PENDING order, preventing
@@ -97,6 +109,15 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
         @Param("merchType") MerchType merchType,
         @Param("status") OrderStatus status);
 
+    @Query("SELECT COUNT(oi) > 0 FROM OrderItem oi " +
+           "WHERE oi.order.student.studentId = :studentId " +
+           "AND oi.merchVariantItem.merchVariant.merch.merchId = :merchId " +
+           "AND oi.orderStatus NOT IN :excludedStatuses")
+    boolean existsByStudentIdAndMerchIdAndOrderStatusNotIn(
+        @Param("studentId") String studentId,
+        @Param("merchId") Long merchId,
+        @Param("excludedStatuses") List<OrderStatus> excludedStatuses);
+
     /**
      * Count total customers (order items) for a specific merch.
      * Used for quick summary without loading full page data.
@@ -109,6 +130,8 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     /* check if any order items reference merch variant items */
     boolean existsByMerchVariantItemMerchVariantMerchVariantId(Long merchVariantId);
+
+    boolean existsByMerchVariantItemMerchVariantItemId(Long merchVariantItemId);
     
     /* check if any order items reference a specific merch */
     @Query("SELECT COUNT(oi) > 0 FROM OrderItem oi WHERE oi.merchVariantItem.merchVariant.merch.merchId = :merchId")

--- a/src/main/java/org/csps/backend/repository/OrderRepository.java
+++ b/src/main/java/org/csps/backend/repository/OrderRepository.java
@@ -17,6 +17,10 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecificationExecutor<Order> {
+
+    @Override
+    @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
+    List<Order> findAll();
     
     @Query("SELECT DISTINCT o FROM Order o LEFT JOIN FETCH o.orderItems oi LEFT JOIN FETCH oi.merchVariantItem mvi LEFT JOIN FETCH mvi.merchVariant mv LEFT JOIN FETCH mv.merch LEFT JOIN FETCH o.student s LEFT JOIN FETCH s.userAccount ua LEFT JOIN FETCH ua.userProfile WHERE o.student.studentId = :studentId")
     List<Order> findByStudentId(String studentId);
@@ -27,6 +31,9 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
 
     @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
     Optional<Order> findByOrderIdAndStudentStudentId(Long orderId, String studentId);
+
+    @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
+    Optional<Order> findByOrderId(Long orderId);
 
     @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
     Page<Order> findAllByOrderByOrderDateDesc(Pageable pageable);
@@ -43,9 +50,18 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
     
     @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile"}, type = EntityGraph.EntityGraphType.FETCH)
     List<Order> findByOrderDateBetweenAndOrderStatus(LocalDateTime start, LocalDateTime end, OrderStatus status);
+
+    @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
+    List<Order> findByOrderDateBetweenAndOrderStatusIn(
+            LocalDateTime start,
+            LocalDateTime end,
+            List<OrderStatus> statuses);
     
     @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile"}, type = EntityGraph.EntityGraphType.FETCH)
     List<Order> findByOrderStatus(OrderStatus status);
+
+    @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
+    List<Order> findByOrderStatusIn(List<OrderStatus> statuses);
 }
 
     

--- a/src/main/java/org/csps/backend/repository/OrderRepository.java
+++ b/src/main/java/org/csps/backend/repository/OrderRepository.java
@@ -2,6 +2,7 @@ package org.csps.backend.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.enums.OrderStatus;
@@ -10,6 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -24,11 +26,18 @@ public interface OrderRepository extends JpaRepository<Order, Long>, JpaSpecific
     Page<Order> findByStudentId(String studentId, Pageable pageable);
 
     @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
+    Optional<Order> findByOrderIdAndStudentStudentId(Long orderId, String studentId);
+
+    @EntityGraph(value = "Order.withItemsAndDetails", type = EntityGraph.EntityGraphType.FETCH)
     Page<Order> findAllByOrderByOrderDateDesc(Pageable pageable);
     
     /* efficient paginated query for transactions with eager loading to prevent N+1 queries */
     @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile", "orderItems", "orderItems.merchVariantItem", "orderItems.merchVariantItem.merchVariant", "orderItems.merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
     Page<Order> findAll(Pageable pageable);
+
+    @Override
+    @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile", "orderItems", "orderItems.merchVariantItem", "orderItems.merchVariantItem.merchVariant", "orderItems.merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    Page<Order> findAll(Specification<Order> spec, Pageable pageable);
     
     List<Order> findByOrderDateBetween(LocalDateTime start, LocalDateTime end);
     

--- a/src/main/java/org/csps/backend/repository/StudentMembershipRepository.java
+++ b/src/main/java/org/csps/backend/repository/StudentMembershipRepository.java
@@ -1,5 +1,6 @@
 package org.csps.backend.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,6 +52,9 @@ public interface StudentMembershipRepository extends JpaRepository<StudentMember
     /* check if student has active membership */
     @Query("SELECT CASE WHEN COUNT(sm) > 0 THEN true ELSE false END FROM StudentMembership sm WHERE sm.student.studentId = :studentId AND sm.active = true")
     boolean hasActiveMembership(@Param("studentId") String studentId);
+
+    @Query("SELECT DISTINCT sm.student.studentId FROM StudentMembership sm WHERE sm.active = true AND sm.student.studentId IN :studentIds")
+    List<String> findActiveStudentIdsByStudentIdIn(@Param("studentIds") Collection<String> studentIds);
 
     /**
      * Find ALL active student memberships (unpaginated) with eager loading.

--- a/src/main/java/org/csps/backend/repository/StudentMembershipRepository.java
+++ b/src/main/java/org/csps/backend/repository/StudentMembershipRepository.java
@@ -1,5 +1,6 @@
 package org.csps.backend.repository;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -25,6 +26,8 @@ public interface StudentMembershipRepository extends JpaRepository<StudentMember
     
     @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile"}, type = EntityGraph.EntityGraphType.FETCH)
     Optional<StudentMembership> findByStudentStudentIdAndYearStartAndYearEnd(String studentId, int yearStart, int yearEnd);
+
+    List<StudentMembership> findByYearStartAndYearEnd(int yearStart, int yearEnd);
     
     /* eager load student and related user profile for dashboard use */
     @EntityGraph(attributePaths = {"student", "student.userAccount", "student.userAccount.userProfile"}, type = EntityGraph.EntityGraphType.FETCH)

--- a/src/main/java/org/csps/backend/repository/TicketFreebieAssignmentRepository.java
+++ b/src/main/java/org/csps/backend/repository/TicketFreebieAssignmentRepository.java
@@ -1,0 +1,33 @@
+package org.csps.backend.repository;
+
+import java.util.List;
+
+import org.csps.backend.domain.entities.TicketFreebieAssignment;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TicketFreebieAssignmentRepository extends JpaRepository<TicketFreebieAssignment, Long> {
+    @EntityGraph(attributePaths = {"orderItem", "orderItem.order", "orderItem.order.student", "orderItem.order.student.userAccount", "orderItem.order.student.userAccount.userProfile", "orderItem.merchVariantItem", "orderItem.merchVariantItem.merchVariant", "orderItem.merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    List<TicketFreebieAssignment> findByOrderItemOrderItemId(Long orderItemId);
+
+    @EntityGraph(attributePaths = {"orderItem", "orderItem.order", "orderItem.order.student", "orderItem.order.student.userAccount", "orderItem.order.student.userAccount.userProfile", "orderItem.merchVariantItem", "orderItem.merchVariantItem.merchVariant", "orderItem.merchVariantItem.merchVariant.merch"}, type = EntityGraph.EntityGraphType.FETCH)
+    List<TicketFreebieAssignment> findByOrderItemOrderItemIdIn(List<Long> orderItemIds);
+
+    void deleteByOrderItemOrderItemId(Long orderItemId);
+
+    void deleteByOrderItemOrderItemIdIn(List<Long> orderItemIds);
+
+    @Query("SELECT COUNT(tfa) FROM TicketFreebieAssignment tfa WHERE tfa.ticketFreebieConfig.ticketFreebieConfigId = :configId AND tfa.selectedSize = :size")
+    long countByConfigIdAndSelectedSize(@Param("configId") Long configId, @Param("size") ClothingSizing size);
+
+    @Query("SELECT COUNT(tfa) FROM TicketFreebieAssignment tfa WHERE tfa.ticketFreebieConfig.ticketFreebieConfigId = :configId AND LOWER(tfa.selectedColor) = LOWER(:color)")
+    long countByConfigIdAndSelectedColor(@Param("configId") Long configId, @Param("color") String color);
+
+    @Query("SELECT COUNT(tfa) FROM TicketFreebieAssignment tfa WHERE tfa.ticketFreebieConfig.ticketFreebieConfigId = :configId AND LOWER(tfa.selectedDesign) = LOWER(:design)")
+    long countByConfigIdAndSelectedDesign(@Param("configId") Long configId, @Param("design") String design);
+}

--- a/src/main/java/org/csps/backend/repository/TicketFreebieConfigRepository.java
+++ b/src/main/java/org/csps/backend/repository/TicketFreebieConfigRepository.java
@@ -1,0 +1,19 @@
+package org.csps.backend.repository;
+
+import java.util.List;
+
+import org.csps.backend.domain.entities.TicketFreebieConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TicketFreebieConfigRepository extends JpaRepository<TicketFreebieConfig, Long> {
+    List<TicketFreebieConfig> findByTicketMerchMerchIdOrderByDisplayOrderAscTicketFreebieConfigIdAsc(Long ticketMerchId);
+
+    List<TicketFreebieConfig> findByTicketMerchMerchIdInOrderByTicketMerchMerchIdAscDisplayOrderAscTicketFreebieConfigIdAsc(
+            List<Long> ticketMerchIds);
+
+    boolean existsByTicketMerchMerchId(Long ticketMerchId);
+
+    void deleteByTicketMerchMerchId(Long ticketMerchId);
+}

--- a/src/main/java/org/csps/backend/repository/specification/OrderSpecification.java
+++ b/src/main/java/org/csps/backend/repository/specification/OrderSpecification.java
@@ -1,5 +1,6 @@
 package org.csps.backend.repository.specification;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -13,6 +14,8 @@ import org.csps.backend.domain.enums.OrderStatus;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Predicate;
@@ -27,57 +30,81 @@ public class OrderSpecification {
      * supports filtering by student name, student id, status, and date range
      */
     public static Specification<Order> withFilters(OrderSearchDTO searchDTO) {
+        return withFilters(searchDTO, null);
+    }
+
+    public static Specification<Order> withFilters(OrderSearchDTO searchDTO, String enforcedStudentId) {
         return (root, query, cb) -> {
             List<Predicate> predicates = new ArrayList<>();
-            
-            if (Objects.nonNull(searchDTO)) {
-                // join with student entity
-                Join<Order, Student> studentJoin = root.join("student", JoinType.LEFT);
-                
-                // join with useraccount entity
-                Join<Student, UserAccount> userAccountJoin = studentJoin.join("userAccount", JoinType.LEFT);
-                
-                // join with userprofile entity
-                Join<UserAccount, UserProfile> userProfileJoin = userAccountJoin.join("userProfile", JoinType.LEFT);
-                
-                // filter by student name (first name or last name)
-                if (Objects.nonNull(searchDTO.getStudentName()) && !searchDTO.getStudentName().isEmpty()) {
-                    String nameLike = "%" + searchDTO.getStudentName().toLowerCase().trim() + "%";
-                    predicates.add(
-                        cb.or(
-                            cb.like(cb.lower(userProfileJoin.get("firstName")), nameLike),
-                            cb.like(cb.lower(userProfileJoin.get("lastName")), nameLike)
-                        )
-                    );
-                }
-                
-                // filter by student id
-                if (Objects.nonNull(searchDTO.getStudentId()) && !searchDTO.getStudentId().isEmpty() && searchDTO.getStudentId() != null) {
-                    predicates.add(cb.equal(studentJoin.get("studentId"), searchDTO.getStudentId().trim()));
-                }
-                
-                // filter by order status
-                if (Objects.nonNull(searchDTO.getStatus()) && !searchDTO.getStatus().isEmpty()) {
-                    try {
-                        OrderStatus status = OrderStatus.valueOf(searchDTO.getStatus().toUpperCase());
-                        predicates.add(cb.equal(root.get("orderStatus"), status));
-                    } catch (IllegalArgumentException e) {
-                        // invalid status enum value, skip this filter
-                    }
-                }
-                
-                // filter by start date
-                if (Objects.nonNull(searchDTO.getStartDate())) {
-                    predicates.add(cb.greaterThanOrEqualTo(root.get("orderDate"), searchDTO.getStartDate()));
-                }
-                
-                // filter by end date
-                if (Objects.nonNull(searchDTO.getEndDate())) {
-                    predicates.add(cb.lessThanOrEqualTo(root.get("orderDate"), searchDTO.getEndDate()));
-                }
+
+            OrderSearchDTO safeSearch = Objects.nonNull(searchDTO) ? searchDTO : new OrderSearchDTO();
+
+            Join<Order, Student> studentJoin = root.join("student", JoinType.LEFT);
+            Join<Student, UserAccount> userAccountJoin = studentJoin.join("userAccount", JoinType.LEFT);
+            Join<UserAccount, UserProfile> userProfileJoin = userAccountJoin.join("userProfile", JoinType.LEFT);
+
+            if (Objects.nonNull(safeSearch.getStudentName()) && !safeSearch.getStudentName().isBlank()) {
+                String nameLike = "%" + normalizeWhitespace(safeSearch.getStudentName()) + "%";
+                Expression<String> fullName = normalizedExpression(
+                        cb,
+                        cb.concat(
+                                cb.concat(userProfileJoin.get("firstName"), " "),
+                                cb.concat(
+                                        cb.concat(cb.coalesce(userProfileJoin.get("middleName"), ""), " "),
+                                        userProfileJoin.get("lastName"))));
+                Expression<String> firstAndLastName = normalizedExpression(
+                        cb,
+                        cb.concat(
+                                cb.concat(userProfileJoin.get("firstName"), " "),
+                                userProfileJoin.get("lastName")));
+
+                predicates.add(cb.or(
+                        cb.like(fullName, nameLike),
+                        cb.like(firstAndLastName, nameLike)));
+            }
+
+            if ((Objects.isNull(enforcedStudentId) || enforcedStudentId.isBlank())
+                    && Objects.nonNull(safeSearch.getStudentId())
+                    && !safeSearch.getStudentId().isBlank()) {
+                predicates.add(cb.equal(studentJoin.get("studentId"), safeSearch.getStudentId().trim()));
+            }
+
+            if (Objects.nonNull(enforcedStudentId) && !enforcedStudentId.isBlank()) {
+                predicates.add(cb.equal(studentJoin.get("studentId"), enforcedStudentId.trim()));
+            }
+
+            if (Objects.nonNull(safeSearch.getStatus()) && !safeSearch.getStatus().isBlank()) {
+                OrderStatus status = OrderStatus.valueOf(safeSearch.getStatus().trim().toUpperCase());
+                predicates.add(cb.equal(root.get("orderStatus"), status));
+            }
+
+            if (Objects.nonNull(safeSearch.getYear())) {
+                LocalDateTime startOfYear = LocalDateTime.of(safeSearch.getYear(), 1, 1, 0, 0);
+                LocalDateTime startOfNextYear = startOfYear.plusYears(1);
+                predicates.add(cb.greaterThanOrEqualTo(root.get("orderDate"), startOfYear));
+                predicates.add(cb.lessThan(root.get("orderDate"), startOfNextYear));
+            }
+
+            if (Objects.nonNull(safeSearch.getStartDate())) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("orderDate"), safeSearch.getStartDate()));
+            }
+
+            if (Objects.nonNull(safeSearch.getEndDate())) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("orderDate"), safeSearch.getEndDate()));
             }
             
             return cb.and(predicates.toArray(new Predicate[0]));
         };
+    }
+
+    private static Expression<String> normalizedExpression(CriteriaBuilder cb, Expression<String> expression) {
+        Expression<String> normalized = cb.lower(cb.trim(expression));
+        normalized = cb.function("replace", String.class, normalized, cb.literal("  "), cb.literal(" "));
+        normalized = cb.function("replace", String.class, normalized, cb.literal("  "), cb.literal(" "));
+        return normalized;
+    }
+
+    private static String normalizeWhitespace(String value) {
+        return value == null ? null : value.trim().replaceAll("\\s+", " ").toLowerCase();
     }
 }

--- a/src/main/java/org/csps/backend/service/AdminService.java
+++ b/src/main/java/org/csps/backend/service/AdminService.java
@@ -15,6 +15,7 @@ public interface AdminService {
     AdminResponseDTO createAdmin(AdminPostRequestDTO adminPostRequestDTO);
     AdminResponseDTO createAdminUnsecure(AdminUnsecureRequestDTO adminUnsecureRequestDTO);
     AdminResponseDTO deleteAdmin(Long adminId);
+    AdminResponseDTO resetAdminPassword(Long adminId);
     
     // New methods
     AdminResponseDTO grantAdminAccess(String studentId, AdminPosition position);

--- a/src/main/java/org/csps/backend/service/CartItemService.java
+++ b/src/main/java/org/csps/backend/service/CartItemService.java
@@ -1,34 +1,56 @@
 package org.csps.backend.service;
 
-import org.csps.backend.domain.dtos.request.CartItemRequestDTO;
-import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
 import java.util.List;
 
+import org.csps.backend.domain.dtos.request.CartItemRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieSelectionRequestDTO;
+import org.csps.backend.domain.dtos.response.CartItemFreebieSelectionResponseDTO;
+import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
+
 public interface CartItemService {
-    
+
     /**
      * Add item to cart.
      */
     CartItemResponseDTO addCartItem(String studentId, CartItemRequestDTO cartItemRequestDTO);
-    
+
+    /**
+     * Get one cart line by merch variant item id.
+     */
+    CartItemResponseDTO getCartItemByMerchVariantItemId(String studentId, Long merchVariantItemId);
+
     /**
      * Remove item from cart.
      */
     void removeCartItem(String studentId, Long merchVariantItemId);
-    
+
     /**
      * Update cart item quantity.
      */
     CartItemResponseDTO updateCartItemQuantity(String studentId, Long merchVariantItemId, int quantity);
-    
+
+    /**
+     * Get the available freebie options and current selection for one cart item.
+     */
+    CartItemFreebieSelectionResponseDTO getCartItemFreebieSelection(
+            String studentId,
+            Long merchVariantItemId);
+
+    /**
+     * Update the selected freebie values for an existing cart item.
+     */
+    CartItemResponseDTO updateCartItemFreebieSelection(
+            String studentId,
+            Long merchVariantItemId,
+            List<TicketFreebieSelectionRequestDTO> freebieSelections);
+
     /**
      * Get all items in student's cart.
      */
     List<CartItemResponseDTO> getCartItems(String studentId);
-    
+
     /**
      * Clear entire cart.
      */
     void clearCart(String studentId);
 }
-

--- a/src/main/java/org/csps/backend/service/MerchCustomerService.java
+++ b/src/main/java/org/csps/backend/service/MerchCustomerService.java
@@ -24,7 +24,7 @@ public interface MerchCustomerService {
      * @param pageable pagination details
      * @return paginated list of MerchCustomerResponseDTO
      */
-    Page<MerchCustomerResponseDTO> getCustomersByMerchId(Long merchId, Pageable pageable);
+    Page<MerchCustomerResponseDTO> getCustomersByMerchId(Long merchId, Pageable pageable, boolean includeFreebies);
 
     /**
      * Get a paginated list of customers who purchased a specific merch,
@@ -35,7 +35,7 @@ public interface MerchCustomerService {
      * @param pageable pagination details
      * @return paginated list of MerchCustomerResponseDTO matching the status
      */
-    Page<MerchCustomerResponseDTO> getCustomersByMerchIdAndStatus(Long merchId, OrderStatus status, Pageable pageable);
+    Page<MerchCustomerResponseDTO> getCustomersByMerchIdAndStatus(Long merchId, OrderStatus status, Pageable pageable, boolean includeFreebies);
 
     /**
      * Get the total count of customers (order items) for a specific merch.
@@ -44,7 +44,7 @@ public interface MerchCustomerService {
      * @param merchId the merch ID to count for
      * @return total number of order items for this merch
      */
-    long getCustomerCountByMerchId(Long merchId);
+    long getCustomerCountByMerchId(Long merchId, boolean includeFreebies);
 
     /**
      * Batch-create orders for a list of students who already paid for a specific merch.
@@ -73,5 +73,5 @@ public interface MerchCustomerService {
      * @param merchId the merch ID to look up customers for
      * @return complete list of MerchCustomerResponseDTO
      */
-    List<MerchCustomerResponseDTO> getAllCustomersByMerchId(Long merchId);
+    List<MerchCustomerResponseDTO> getAllCustomersByMerchId(Long merchId, boolean includeFreebies);
 }

--- a/src/main/java/org/csps/backend/service/MerchVariantItemService.java
+++ b/src/main/java/org/csps/backend/service/MerchVariantItemService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.csps.backend.domain.dtos.request.MerchVariantItemRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchVariantItemResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
 import org.csps.backend.domain.enums.ClothingSizing;
 
 public interface MerchVariantItemService {
@@ -48,4 +49,9 @@ public interface MerchVariantItemService {
      * Get item by ID.
      */
     MerchVariantItemResponseDTO getItemById(Long merchVariantItemId);
+
+    /**
+     * Get all freebie configs available for a merch variant item.
+     */
+    List<TicketFreebieConfigResponseDTO> getFreebiesByMerchVariantItemId(Long merchVariantItemId);
 }

--- a/src/main/java/org/csps/backend/service/OrderItemService.java
+++ b/src/main/java/org/csps/backend/service/OrderItemService.java
@@ -18,7 +18,7 @@ public interface OrderItemService {
     /**
      * Get order item by ID.
      */
-    OrderItemResponseDTO getOrderItemById(Long id);
+    OrderItemResponseDTO getOrderItemById(Long id, String studentId);
 
     /**
      * Filter by order status
@@ -31,13 +31,13 @@ public interface OrderItemService {
     /**
      * Get all order items for a specific order.
      */
-    List<OrderItemResponseDTO> getOrderItemsByOrderId(Long orderId);
+    List<OrderItemResponseDTO> getOrderItemsByOrderId(Long orderId, String studentId);
     
 
     /**
      * Get paginated order items for a specific order.
      */
-    Page<OrderItemResponseDTO> getOrderItemsByOrderIdPaginated(Long orderId, Pageable pageable);
+    Page<OrderItemResponseDTO> getOrderItemsByOrderIdPaginated(Long orderId, Pageable pageable, String studentId);
     
     /**
      * Get all order items for a specific student (paginated).

--- a/src/main/java/org/csps/backend/service/OrderLifecycleService.java
+++ b/src/main/java/org/csps/backend/service/OrderLifecycleService.java
@@ -1,0 +1,12 @@
+package org.csps.backend.service;
+
+import org.csps.backend.domain.entities.Order;
+import org.csps.backend.domain.enums.OrderStatus;
+
+public interface OrderLifecycleService {
+
+    /**
+     * Move an order and its items to a terminal status and restore reserved stock.
+     */
+    Order applyTerminalStatus(Order order, OrderStatus targetStatus);
+}

--- a/src/main/java/org/csps/backend/service/OrderService.java
+++ b/src/main/java/org/csps/backend/service/OrderService.java
@@ -29,7 +29,7 @@ public interface OrderService {
     /**
      * Get order by ID.
      */
-    OrderResponseDTO getOrderById(Long orderId);
+    OrderResponseDTO getOrderById(Long orderId, String studentId);
     
     /**
      * Get all orders for a specific student.
@@ -48,11 +48,16 @@ public interface OrderService {
      * All filter fields are optional.
      * Dynamic pagination and sorting.
      */
-    Page<OrderResponseDTO> searchOrders(OrderSearchDTO searchDTO, Pageable pageable);
+    Page<OrderResponseDTO> searchOrders(OrderSearchDTO searchDTO, Pageable pageable, String studentId);
 
     /**
      * Delete order and all its items.
      */
     void deleteOrder(Long orderId);
+
+    /**
+     * Cancel a pending order owned by the authenticated student.
+     */
+    OrderResponseDTO cancelOrder(String studentId, Long orderId);
 }
 

--- a/src/main/java/org/csps/backend/service/RecoveryTokenService.java
+++ b/src/main/java/org/csps/backend/service/RecoveryTokenService.java
@@ -20,6 +20,11 @@ public interface RecoveryTokenService {
      * mark recovery token as used
      */
     void markTokenAsUsed(String token);
+
+    /**
+     * reset a user's password and consume the recovery token atomically
+     */
+    void resetPassword(String token, String newPassword);
     
     /**
      * get valid recovery token for user

--- a/src/main/java/org/csps/backend/service/RefreshTokenService.java
+++ b/src/main/java/org/csps/backend/service/RefreshTokenService.java
@@ -10,6 +10,6 @@ public interface RefreshTokenService {
     boolean isValidRefreshToken(RefreshToken token);
     void deleteRefreshToken(RefreshToken token);
     void deleteByUserId(Long userId);
-    Optional<String> refreshAccessToken(String accessToken);
+    Optional<String> refreshAccessToken(String refreshToken);
 
 }

--- a/src/main/java/org/csps/backend/service/StudentMembershipService.java
+++ b/src/main/java/org/csps/backend/service/StudentMembershipService.java
@@ -15,6 +15,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface StudentMembershipService {
     StudentMembershipResponseDTO createStudentMembership(StudentMembershipRequestDTO requestDTO);
+    StudentMembershipResponseDTO ensureMembershipForCurrentAcademicYear(String studentId);
     List<StudentMembershipResponseDTO> getAllStudentMemberships();
     List<StudentMembershipResponseDTO> getStudentWithMemberships(String studentId);
     Optional<StudentMembershipResponseDTO> getStudentMembershipById(Long membershipId);

--- a/src/main/java/org/csps/backend/service/StudentService.java
+++ b/src/main/java/org/csps/backend/service/StudentService.java
@@ -2,8 +2,8 @@ package org.csps.backend.service;
 
 import java.util.Optional;
 
+import org.csps.backend.domain.dtos.request.StudentProfileCompletionRequestDTO;
 import org.csps.backend.domain.dtos.request.StudentRequestDTO;
-import org.csps.backend.domain.dtos.request.UserRequestDTO;
 import org.csps.backend.domain.dtos.response.StudentResponseDTO;
 import org.csps.backend.domain.entities.Student;
 import org.springframework.data.domain.Page;
@@ -21,5 +21,5 @@ public interface StudentService {
    String getCurrentStudentId();
    
    /* complete incomplete student profile with full user information */
-   StudentResponseDTO completeStudentProfile(String studentId, UserRequestDTO userRequestDTO);
+   StudentResponseDTO completeStudentProfile(String studentId, StudentProfileCompletionRequestDTO profileRequestDTO);
 }

--- a/src/main/java/org/csps/backend/service/TicketFreebieAssignmentService.java
+++ b/src/main/java/org/csps/backend/service/TicketFreebieAssignmentService.java
@@ -1,0 +1,21 @@
+package org.csps.backend.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.csps.backend.domain.dtos.request.TicketFreebieAssignmentRequestDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO;
+
+public interface TicketFreebieAssignmentService {
+    /** Initialize or update ticket freebie assignments when a new order item is created. */
+    List<TicketFreebieAssignmentResponseDTO> initializeAssignments(Long orderItemId, List<TicketFreebieAssignmentRequestDTO> requests);
+
+    /** Get the effective freebie assignment view for an order item. */
+    List<TicketFreebieAssignmentResponseDTO> getAssignmentsByOrderItemId(Long orderItemId);
+
+    /** Bulk-load effective freebie assignment views for order items. */
+    Map<Long, List<TicketFreebieAssignmentResponseDTO>> getAssignmentsByOrderItemIds(List<Long> orderItemIds);
+
+    /** Admin backfill/edit endpoint for an order item's freebie assignments. */
+    List<TicketFreebieAssignmentResponseDTO> upsertAssignments(Long orderItemId, List<TicketFreebieAssignmentRequestDTO> requests);
+}

--- a/src/main/java/org/csps/backend/service/TicketFreebieConfigService.java
+++ b/src/main/java/org/csps/backend/service/TicketFreebieConfigService.java
@@ -1,0 +1,18 @@
+package org.csps.backend.service;
+
+import java.util.List;
+
+import org.csps.backend.domain.dtos.request.TicketFreebieConfigRequestDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
+import org.csps.backend.domain.entities.Merch;
+
+public interface TicketFreebieConfigService {
+    /** Get all configured freebies for a ticket merch. */
+    List<TicketFreebieConfigResponseDTO> getConfigsByTicketMerchId(Long ticketMerchId);
+
+    /** Get all configured freebies for a ticket merch variant item. */
+    List<TicketFreebieConfigResponseDTO> getConfigsByMerchVariantItemId(Long merchVariantItemId);
+
+    /** Create, replace, or remove ticket freebie configs during merch create/update. */
+    void syncConfigsForMerch(Merch merch, Boolean hasFreebie, List<TicketFreebieConfigRequestDTO> requests);
+}

--- a/src/main/java/org/csps/backend/service/UserService.java
+++ b/src/main/java/org/csps/backend/service/UserService.java
@@ -13,5 +13,6 @@ public interface UserService {
     UserResponseDTO getUserById(Long userId);
     List<UserResponseDTO> getAllUsers();
     void changePassword(Long userId, ChangePasswordRequestDTO requestDTO);
+    void restoreStudentPassword(String studentId);
 
 }

--- a/src/main/java/org/csps/backend/service/impl/AdminServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/AdminServiceImpl.java
@@ -174,6 +174,25 @@ public class AdminServiceImpl implements AdminService {
     }
 
     @Override
+    public AdminResponseDTO resetAdminPassword(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new AdminNotFoundException("Admin not found with ID: " + adminId));
+
+        UserAccount adminUserAccount = admin.getUserAccount();
+        if (adminUserAccount == null || adminUserAccount.getUserAccountId() == null) {
+            throw new AdminNotFoundException("Admin account not found for admin ID: " + adminId);
+        }
+
+        String position = admin.getPosition().toString();
+
+        String defaultPassword = String.format("%s%s", adminPasswordFormat, position);
+        adminUserAccount.setPassword(passwordEncoder.encode(defaultPassword));
+        userAccountRepository.save(adminUserAccount);
+
+        return adminMapper.toResponseDTO(admin);
+    }
+
+    @Override
     public AdminResponseDTO grantAdminAccess(String studentId, AdminPosition position) {
         // Check if student exists
         Student student = studentRepository.findById(studentId)

--- a/src/main/java/org/csps/backend/service/impl/CartItemServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/CartItemServiceImpl.java
@@ -1,13 +1,29 @@
 package org.csps.backend.service.impl;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.csps.backend.domain.dtos.request.CartItemRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieSelectionRequestDTO;
+import org.csps.backend.domain.dtos.response.CartItemFreebieSelectionItemResponseDTO;
+import org.csps.backend.domain.dtos.response.CartItemFreebieSelectionResponseDTO;
 import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
 import org.csps.backend.domain.entities.Cart;
 import org.csps.backend.domain.entities.CartItem;
+import org.csps.backend.domain.entities.CartItemFreebieSelection;
 import org.csps.backend.domain.entities.MerchVariantItem;
+import org.csps.backend.domain.entities.TicketFreebieConfig;
 import org.csps.backend.domain.entities.composites.CartItemId;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.MerchType;
+import org.csps.backend.domain.enums.OrderStatus;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
 import org.csps.backend.exception.CartItemNotFoundException;
 import org.csps.backend.exception.CartNotFoundException;
 import org.csps.backend.exception.InvalidRequestException;
@@ -16,7 +32,10 @@ import org.csps.backend.mapper.CartItemMapper;
 import org.csps.backend.repository.CartItemRepository;
 import org.csps.backend.repository.CartRepository;
 import org.csps.backend.repository.MerchVariantItemRepository;
+import org.csps.backend.repository.OrderItemRepository;
+import org.csps.backend.repository.TicketFreebieConfigRepository;
 import org.csps.backend.service.CartItemService;
+import org.csps.backend.service.TicketFreebieConfigService;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -26,163 +45,488 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CartItemServiceImpl implements CartItemService {
 
+    private static final String ITEM_ALREADY_ADDED = "ITEM ALREADY ADDED IN THE CART";
+    private static final String ITEM_ALREADY_IN_CART_OR_ORDER = "Item is already in the cart / order";
+
     private final CartItemRepository cartItemRepository;
     private final MerchVariantItemRepository merchVariantItemRepository;
     private final CartRepository cartRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final TicketFreebieConfigRepository ticketFreebieConfigRepository;
     private final CartItemMapper cartItemMapper;
-    
+    private final TicketFreebieConfigService ticketFreebieConfigService;
+
     @Override
     @Transactional
     public CartItemResponseDTO addCartItem(String studentId, CartItemRequestDTO cartItemRequestDTO) {
+        validateStudentId(studentId);
         if (cartItemRequestDTO == null) {
             throw new InvalidRequestException("Cart item request is required");
         }
-        
-        String cartId = studentId;
+
         Long merchVariantItemId = cartItemRequestDTO.getMerchVariantItemId();
         int quantity = cartItemRequestDTO.getQuantity();
-        
-        if (cartId == null || cartId.isEmpty()) {
-            throw new InvalidRequestException("Cart ID is required");
-        }
-        
         if (merchVariantItemId == null || merchVariantItemId <= 0) {
             throw new InvalidRequestException("Merch variant item ID is required");
         }
-        
         if (quantity <= 0) {
             throw new InvalidRequestException("Quantity must be greater than 0");
         }
 
-        // Verify cart exists
-        Cart cart = cartRepository.findById(cartId)
+        Cart cart = cartRepository.findById(studentId)
                 .orElseThrow(() -> new CartNotFoundException("Cart not found"));
-
-        // Verify merch variant item exists
         MerchVariantItem merchVariantItem = merchVariantItemRepository.findById(merchVariantItemId)
                 .orElseThrow(() -> new MerchVariantNotFoundException("Merch variant item not found"));
 
-        // Check stock availability
         if (quantity > merchVariantItem.getStockQuantity()) {
-            throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity() + 
-                    ", Requested: " + quantity);
+            throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity()
+                    + ", Requested: " + quantity);
         }
 
-        CartItemId cartItemId = new CartItemId(cartId, merchVariantItemId);
+        MerchType merchType = merchVariantItem.getMerchVariant().getMerch().getMerchType();
+        List<ValidatedCartSelection> normalizedSelections = validateAndNormalizeSelections(
+                merchVariantItem,
+                cartItemRequestDTO.getFreebieSelections(),
+                true);
 
-        // Check if item already exists in cart
+        if (merchType == MerchType.TICKET || merchType == MerchType.MEMBERSHIP) {
+            validateSingleEntryRules(studentId, merchVariantItem, quantity);
+            CartItemId cartItemId = new CartItemId(studentId, merchVariantItemId);
+            if (merchType == MerchType.MEMBERSHIP && cartItemRepository.existsById(cartItemId)) {
+                throw new InvalidRequestException(ITEM_ALREADY_ADDED);
+            }
+
+            CartItem cartItem = CartItem.builder()
+                    .cartItemId(cartItemId)
+                    .cart(cart)
+                    .merchVariantItem(merchVariantItem)
+                    .quantity(1)
+                    .build();
+            applySelections(cartItem, normalizedSelections);
+            return enrichResponse(cartItemMapper.toResponseDTO(cartItemRepository.save(cartItem)), cartItem);
+        }
+
+        CartItemId cartItemId = new CartItemId(studentId, merchVariantItemId);
         CartItem cartItem = cartItemRepository.findById(cartItemId)
                 .orElse(CartItem.builder()
-                        .id(cartItemId)
+                        .cartItemId(cartItemId)
                         .cart(cart)
                         .merchVariantItem(merchVariantItem)
                         .quantity(0)
                         .build());
 
-        // Validate total quantity doesn't exceed stock
         int totalQuantity = cartItem.getQuantity() + quantity;
         if (totalQuantity > merchVariantItem.getStockQuantity()) {
-            throw new InvalidRequestException("Total quantity (" + totalQuantity + ") exceeds available stock (" + 
-                    merchVariantItem.getStockQuantity() + ")");
+            throw new InvalidRequestException("Total quantity (" + totalQuantity + ") exceeds available stock ("
+                    + merchVariantItem.getStockQuantity() + ")");
         }
 
         cartItem.setQuantity(totalQuantity);
         cartItem = cartItemRepository.save(cartItem);
+        return enrichResponse(cartItemMapper.toResponseDTO(cartItem), cartItem);
+    }
 
-        return cartItemMapper.toResponseDTO(cartItem);
+    @Override
+    public CartItemResponseDTO getCartItemByMerchVariantItemId(String studentId, Long merchVariantItemId) {
+        validateStudentId(studentId);
+        if (merchVariantItemId == null || merchVariantItemId <= 0) {
+            throw new InvalidRequestException("Merch variant item ID is required");
+        }
+
+        CartItem cartItem = getCartItem(studentId, merchVariantItemId);
+        return enrichResponse(cartItemMapper.toResponseDTO(cartItem), cartItem);
     }
 
     @Override
     @Transactional
     public void removeCartItem(String studentId, Long merchVariantItemId) {
-        if (studentId == null || studentId.isEmpty()) {
-            throw new InvalidRequestException("Student ID is required");
-        }
-        
+        validateStudentId(studentId);
         if (merchVariantItemId == null || merchVariantItemId <= 0) {
             throw new InvalidRequestException("Merch variant item ID is required");
         }
 
-        // Get the cart
-        Cart cart = cartRepository.findById(studentId)
-                .orElseThrow(() -> new CartNotFoundException("Cart not found"));
-        
-        // Remove the item from cart's items collection
         CartItemId cartItemId = new CartItemId(studentId, merchVariantItemId);
-        boolean removed = cart.getItems().removeIf(item -> item.getId().equals(cartItemId));
-        
-        if (!removed) {
+        if (!cartItemRepository.existsById(cartItemId)) {
             throw new CartItemNotFoundException("Cart item not found");
         }
-        
-        // Save the cart (cascade will handle deletion)
-        cartRepository.save(cart);
+        cartItemRepository.deleteById(cartItemId);
     }
 
     @Override
     @Transactional
     public CartItemResponseDTO updateCartItemQuantity(String studentId, Long merchVariantItemId, int quantity) {
-        if (studentId == null || studentId.isEmpty()) {
-            throw new InvalidRequestException("Student ID is required");
-        }
-        
+        validateStudentId(studentId);
         if (merchVariantItemId == null || merchVariantItemId <= 0) {
             throw new InvalidRequestException("Merch variant item ID is required");
         }
-        
         if (quantity < 0) {
             throw new InvalidRequestException("Quantity cannot be negative");
         }
 
-        CartItemId cartItemId = new CartItemId(studentId, merchVariantItemId);
-        
-        CartItem cartItem = cartItemRepository.findById(cartItemId)
-                .orElseThrow(() -> new CartItemNotFoundException("Cart item not found"));
+        CartItem cartItem = getCartItem(studentId, merchVariantItemId);
+        MerchType merchType = cartItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType();
+        if ((merchType == MerchType.TICKET || merchType == MerchType.MEMBERSHIP) && quantity > 1) {
+            throw new InvalidRequestException("Quantity for ticket and membership items must remain 1");
+        }
 
-        // If quantity is 0, delete the item
         if (quantity == 0) {
-            cartItemRepository.deleteById(cartItemId);
+            cartItemRepository.delete(cartItem);
             return null;
         }
 
-        // Verify stock availability
-        MerchVariantItem merchVariantItem = cartItem.getMerchVariantItem();
-        if (quantity > merchVariantItem.getStockQuantity()) {
-            throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity() + 
-                    ", Requested: " + quantity);
+        if (quantity > cartItem.getMerchVariantItem().getStockQuantity()) {
+            throw new InvalidRequestException("Insufficient stock. Available: "
+                    + cartItem.getMerchVariantItem().getStockQuantity() + ", Requested: " + quantity);
         }
 
         cartItem.setQuantity(quantity);
         cartItem = cartItemRepository.save(cartItem);
+        return enrichResponse(cartItemMapper.toResponseDTO(cartItem), cartItem);
+    }
 
-        return cartItemMapper.toResponseDTO(cartItem);
+    @Override
+    @Transactional
+    public CartItemFreebieSelectionResponseDTO getCartItemFreebieSelection(String studentId, Long merchVariantItemId) {
+        validateStudentId(studentId);
+        if (merchVariantItemId == null || merchVariantItemId <= 0) {
+            throw new InvalidRequestException("Merch variant item ID is required");
+        }
+
+        CartItem cartItem = getCartItem(studentId, merchVariantItemId);
+        List<TicketFreebieConfigResponseDTO> configs = getRequiredCartFreebieConfigs(cartItem);
+        Map<Long, CartItemFreebieSelection> selectedByConfigId = cartItem.getFreebieSelections().stream()
+                .filter(selection -> selection.getTicketFreebieConfig() != null && selection.getTicketFreebieConfig().getTicketFreebieConfigId() != null)
+                .collect(Collectors.toMap(selection -> selection.getTicketFreebieConfig().getTicketFreebieConfigId(), selection -> selection));
+
+        return CartItemFreebieSelectionResponseDTO.builder()
+                .merchVariantItemId(merchVariantItemId)
+                .merchId(cartItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchId())
+                .freebies(configs.stream().map(config -> {
+                    CartItemFreebieSelection selected = selectedByConfigId.get(config.getTicketFreebieConfigId());
+                    return CartItemFreebieSelectionItemResponseDTO.builder()
+                            .ticketFreebieConfigId(config.getTicketFreebieConfigId())
+                            .displayOrder(config.getDisplayOrder())
+                            .category(config.getCategory())
+                            .freebieName(config.getFreebieName())
+                            .clothingSubtype(config.getClothingSubtype())
+                            .availableSizes(config.getSizes())
+                            .availableColors(config.getColors())
+                            .availableDesigns(config.getDesigns())
+                            .selectedSize(selected == null ? null : selected.getSelectedSize())
+                            .selectedColor(selected == null ? null : selected.getSelectedColor())
+                            .selectedDesign(selected == null ? null : selected.getSelectedDesign())
+                            .build();
+                }).toList())
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public CartItemResponseDTO updateCartItemFreebieSelection(
+            String studentId,
+            Long merchVariantItemId,
+            List<TicketFreebieSelectionRequestDTO> freebieSelections) {
+        validateStudentId(studentId);
+        if (merchVariantItemId == null || merchVariantItemId <= 0) {
+            throw new InvalidRequestException("Merch variant item ID is required");
+        }
+
+        CartItem cartItem = getCartItem(studentId, merchVariantItemId);
+        List<ValidatedCartSelection> normalizedSelections = validateAndNormalizeSelections(
+                cartItem.getMerchVariantItem(),
+                freebieSelections,
+                true);
+
+        applySelections(cartItem, normalizedSelections);
+        CartItem updatedCartItem = cartItemRepository.save(cartItem);
+        return enrichResponse(cartItemMapper.toResponseDTO(updatedCartItem), updatedCartItem);
     }
 
     @Override
     public List<CartItemResponseDTO> getCartItems(String studentId) {
-        if (studentId == null || studentId.isEmpty()) {
-            throw new InvalidRequestException("Student ID is required");
-        }
-
-        Cart cart = cartRepository.findById(studentId)
+        validateStudentId(studentId);
+        Cart cart = cartRepository.findByIdWithItems(studentId)
                 .orElseThrow(() -> new CartNotFoundException("Cart not found"));
 
         return cart.getItems().stream()
-                .map(cartItemMapper::toResponseDTO)
+                .map(item -> enrichResponse(cartItemMapper.toResponseDTO(item), item))
                 .toList();
     }
 
     @Override
     @Transactional
     public void clearCart(String studentId) {
+        validateStudentId(studentId);
+        Cart cart = cartRepository.findById(studentId)
+                .orElseThrow(() -> new CartNotFoundException("Cart not found"));
+        cart.getItems().clear();
+        cartRepository.save(cart);
+    }
+
+    private void applySelections(CartItem cartItem, List<ValidatedCartSelection> selections) {
+        cartItem.setSelectedFreebieSize(null);
+        cartItem.setSelectedFreebieColor(null);
+        cartItem.setSelectedFreebieDesign(null);
+
+        Map<Long, CartItemFreebieSelection> existingByConfigId = cartItem.getFreebieSelections().stream()
+                .filter(selection -> selection.getTicketFreebieConfig() != null
+                        && selection.getTicketFreebieConfig().getTicketFreebieConfigId() != null)
+                .collect(Collectors.toMap(
+                        selection -> selection.getTicketFreebieConfig().getTicketFreebieConfigId(),
+                        selection -> selection,
+                        (existing, ignored) -> existing,
+                        LinkedHashMap::new));
+
+        Set<Long> retainedConfigIds = selections.stream()
+                .map(selection -> selection.config().getTicketFreebieConfigId())
+                .collect(Collectors.toSet());
+
+        cartItem.getFreebieSelections().removeIf(existingSelection -> {
+            TicketFreebieConfig config = existingSelection.getTicketFreebieConfig();
+            return config == null
+                    || config.getTicketFreebieConfigId() == null
+                    || !retainedConfigIds.contains(config.getTicketFreebieConfigId());
+        });
+
+        for (ValidatedCartSelection selection : selections) {
+            Long configId = selection.config().getTicketFreebieConfigId();
+            CartItemFreebieSelection freebieSelection = existingByConfigId.get(configId);
+            if (freebieSelection == null) {
+                freebieSelection = CartItemFreebieSelection.builder()
+                        .cartItem(cartItem)
+                        .build();
+                cartItem.getFreebieSelections().add(freebieSelection);
+            }
+
+            freebieSelection.setCartItem(cartItem);
+            freebieSelection.setTicketFreebieConfig(selection.config());
+            freebieSelection.setSelectedSize(selection.selectedSize());
+            freebieSelection.setSelectedColor(selection.selectedColor());
+            freebieSelection.setSelectedDesign(selection.selectedDesign());
+        }
+    }
+
+    private void validateSingleEntryRules(String studentId, MerchVariantItem merchVariantItem, int quantity) {
+        if (quantity != 1) {
+            throw new InvalidRequestException("Quantity for ticket and membership items must be exactly 1");
+        }
+
+        MerchType merchType = merchVariantItem.getMerchVariant().getMerch().getMerchType();
+        if (merchType == MerchType.TICKET) {
+            Long merchId = merchVariantItem.getMerchVariant().getMerch().getMerchId();
+            if (cartItemRepository.existsByStudentIdAndMerchId(studentId, merchId)
+                    || hasActiveOrderForMerch(studentId, merchId)) {
+                throw new InvalidRequestException(ITEM_ALREADY_IN_CART_OR_ORDER);
+            }
+            return;
+        }
+
+        if (cartItemRepository.existsByStudentIdAndMerchType(studentId, merchType)) {
+            throw new InvalidRequestException(ITEM_ALREADY_ADDED);
+        }
+    }
+
+    private boolean hasActiveOrderForMerch(String studentId, Long merchId) {
+        return orderItemRepository.existsByStudentIdAndMerchIdAndOrderStatusNotIn(
+                studentId,
+                merchId,
+                List.of(OrderStatus.CANCELLED, OrderStatus.REJECTED));
+    }
+
+    private CartItemResponseDTO enrichResponse(CartItemResponseDTO response, CartItem cartItem) {
+        MerchVariantItem merchVariantItem = cartItem.getMerchVariantItem();
+        if (merchVariantItem == null || merchVariantItem.getMerchVariant() == null
+                || merchVariantItem.getMerchVariant().getMerch() == null) {
+            return response;
+        }
+
+        var merch = merchVariantItem.getMerchVariant().getMerch();
+        if (merch.getMerchType() != MerchType.TICKET || !Boolean.TRUE.equals(merch.getHasFreebie())) {
+            response.setHasFreebie(false);
+            response.setFreebieSelections(List.of());
+            return response;
+        }
+
+        List<TicketFreebieConfigResponseDTO> configs = ticketFreebieConfigService.getConfigsByTicketMerchId(merch.getMerchId());
+        Map<Long, CartItemFreebieSelection> selectedByConfigId = cartItem.getFreebieSelections().stream()
+                .filter(selection -> selection.getTicketFreebieConfig() != null && selection.getTicketFreebieConfig().getTicketFreebieConfigId() != null)
+                .collect(Collectors.toMap(selection -> selection.getTicketFreebieConfig().getTicketFreebieConfigId(), selection -> selection));
+
+        response.setHasFreebie(!configs.isEmpty());
+        response.setFreebieSelections(configs.stream().map(config -> {
+            CartItemFreebieSelection selected = selectedByConfigId.get(config.getTicketFreebieConfigId());
+            return CartItemFreebieSelectionItemResponseDTO.builder()
+                    .ticketFreebieConfigId(config.getTicketFreebieConfigId())
+                    .displayOrder(config.getDisplayOrder())
+                    .category(config.getCategory())
+                    .freebieName(config.getFreebieName())
+                    .clothingSubtype(config.getClothingSubtype())
+                    .availableSizes(config.getSizes())
+                    .availableColors(config.getColors())
+                    .availableDesigns(config.getDesigns())
+                    .selectedSize(selected == null ? null : selected.getSelectedSize())
+                    .selectedColor(selected == null ? null : selected.getSelectedColor())
+                    .selectedDesign(selected == null ? null : selected.getSelectedDesign())
+                    .build();
+        }).toList());
+        return response;
+    }
+
+    private List<ValidatedCartSelection> validateAndNormalizeSelections(
+            MerchVariantItem merchVariantItem,
+            List<TicketFreebieSelectionRequestDTO> selections,
+            boolean requireCompleteSelections) {
+        if (merchVariantItem == null || merchVariantItem.getMerchVariant() == null
+                || merchVariantItem.getMerchVariant().getMerch() == null) {
+            throw new InvalidRequestException("Merch details are incomplete");
+        }
+
+        var merch = merchVariantItem.getMerchVariant().getMerch();
+        boolean isTicketWithFreebies = merch.getMerchType() == MerchType.TICKET && Boolean.TRUE.equals(merch.getHasFreebie());
+        List<TicketFreebieSelectionRequestDTO> normalizedRequests = selections == null ? List.of() : selections;
+
+        if (!isTicketWithFreebies) {
+            if (!normalizedRequests.isEmpty()) {
+                throw new InvalidRequestException("Freebie selection is only allowed for ticket merch with freebies");
+            }
+            return List.of();
+        }
+
+        List<TicketFreebieConfig> configs = ticketFreebieConfigRepository.findByTicketMerchMerchIdOrderByDisplayOrderAscTicketFreebieConfigIdAsc(merch.getMerchId());
+        if (configs.isEmpty()) {
+            throw new InvalidRequestException("Ticket freebie config is missing");
+        }
+
+        if (normalizedRequests.isEmpty()) {
+            if (requireCompleteSelections) {
+                throw new InvalidRequestException("Freebie selections are required before adding this ticket to cart");
+            }
+            return List.of();
+        }
+
+        Map<Long, TicketFreebieSelectionRequestDTO> requestByConfigId = new LinkedHashMap<>();
+        for (TicketFreebieSelectionRequestDTO request : normalizedRequests) {
+            if (request == null || request.getTicketFreebieConfigId() == null) {
+                throw new InvalidRequestException("Each freebie selection must include ticketFreebieConfigId");
+            }
+            if (requestByConfigId.put(request.getTicketFreebieConfigId(), request) != null) {
+                throw new InvalidRequestException("Duplicate freebie selections are not allowed for the same config");
+            }
+        }
+
+        List<ValidatedCartSelection> normalizedSelections = new ArrayList<>();
+        for (TicketFreebieConfig config : configs) {
+            TicketFreebieSelectionRequestDTO request = requestByConfigId.remove(config.getTicketFreebieConfigId());
+            if (request == null) {
+                throw new InvalidRequestException("Missing freebie selection for config " + config.getFreebieName());
+            }
+
+            ClothingSizing selectedSize = request.getSelectedSize();
+            String selectedColor = normalizeOptionalText(request.getSelectedColor());
+            String selectedDesign = normalizeOptionalText(request.getSelectedDesign());
+
+            if (config.getCategory() == TicketFreebieCategory.CLOTHING) {
+                validateClothingSelection(config, selectedSize, selectedColor, selectedDesign);
+                normalizedSelections.add(new ValidatedCartSelection(config, selectedSize, selectedColor, null));
+            } else {
+                validateNonClothingSelection(config, selectedSize, selectedColor, selectedDesign);
+                normalizedSelections.add(new ValidatedCartSelection(config, null, null, selectedDesign));
+            }
+        }
+
+        if (!requestByConfigId.isEmpty()) {
+            throw new InvalidRequestException("Submitted freebie selections contain unknown configs");
+        }
+        return normalizedSelections;
+    }
+
+    private void validateClothingSelection(
+            TicketFreebieConfig config,
+            ClothingSizing selectedSize,
+            String selectedColor,
+            String selectedDesign) {
+        if (selectedSize == null || selectedColor == null) {
+            throw new InvalidRequestException("Freebie size and color are required for " + config.getFreebieName());
+        }
+        if (selectedDesign != null) {
+            throw new InvalidRequestException("Freebie design is not allowed for clothing freebies");
+        }
+
+        Set<ClothingSizing> allowedSizes = config.getSizeOptions().stream().map(option -> option.getSizeLabel()).collect(Collectors.toSet());
+        Set<String> allowedColors = config.getColorOptions().stream()
+                .map(option -> option.getColorLabel().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+
+        if (!allowedSizes.contains(selectedSize)) {
+            throw new InvalidRequestException("Selected freebie size is not allowed for " + config.getFreebieName());
+        }
+        if (!allowedColors.contains(selectedColor.toLowerCase(Locale.ROOT))) {
+            throw new InvalidRequestException("Selected freebie color is not allowed for " + config.getFreebieName());
+        }
+    }
+
+    private void validateNonClothingSelection(
+            TicketFreebieConfig config,
+            ClothingSizing selectedSize,
+            String selectedColor,
+            String selectedDesign) {
+        if (selectedDesign == null) {
+            throw new InvalidRequestException("Freebie design is required for " + config.getFreebieName());
+        }
+        if (selectedSize != null || selectedColor != null) {
+            throw new InvalidRequestException("Freebie size and color are not allowed for non-clothing freebies");
+        }
+
+        Set<String> allowedDesigns = config.getDesignOptions().stream()
+                .map(option -> option.getDesignLabel().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+        if (!allowedDesigns.contains(selectedDesign.toLowerCase(Locale.ROOT))) {
+            throw new InvalidRequestException("Selected freebie design is not allowed for " + config.getFreebieName());
+        }
+    }
+
+    private List<TicketFreebieConfigResponseDTO> getRequiredCartFreebieConfigs(CartItem cartItem) {
+        if (cartItem == null || cartItem.getMerchVariantItem() == null
+                || cartItem.getMerchVariantItem().getMerchVariant() == null
+                || cartItem.getMerchVariantItem().getMerchVariant().getMerch() == null) {
+            throw new InvalidRequestException("Cart item merch details are incomplete");
+        }
+
+        var merch = cartItem.getMerchVariantItem().getMerchVariant().getMerch();
+        if (merch.getMerchType() != MerchType.TICKET || !Boolean.TRUE.equals(merch.getHasFreebie())) {
+            throw new InvalidRequestException("This cart item does not support freebies");
+        }
+
+        List<TicketFreebieConfigResponseDTO> configs = ticketFreebieConfigService.getConfigsByTicketMerchId(merch.getMerchId());
+        if (configs.isEmpty()) {
+            throw new InvalidRequestException("Ticket freebie config is missing");
+        }
+        return configs;
+    }
+
+    private CartItem getCartItem(String studentId, Long merchVariantItemId) {
+        return cartItemRepository.findById(new CartItemId(studentId, merchVariantItemId))
+                .orElseThrow(() -> new CartItemNotFoundException("Cart item not found"));
+    }
+
+    private void validateStudentId(String studentId) {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
+    }
 
-        Cart cart = cartRepository.findById(studentId)
-                .orElseThrow(() -> new CartNotFoundException("Cart not found"));
+    private String normalizeOptionalText(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        String normalized = rawValue.trim().replaceAll("\\s+", " ");
+        return normalized.isEmpty() ? null : normalized;
+    }
 
-        cart.getItems().clear();
-        cartRepository.save(cart);
+    private record ValidatedCartSelection(
+            TicketFreebieConfig config,
+            ClothingSizing selectedSize,
+            String selectedColor,
+            String selectedDesign) {
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/CartItemServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/CartItemServiceImpl.java
@@ -142,7 +142,7 @@ public class CartItemServiceImpl implements CartItemService {
         // If quantity is 0, delete the item
         if (quantity == 0) {
             cartItemRepository.deleteById(cartItemId);
-            throw new CartItemNotFoundException("Cart item removed (quantity set to 0)");
+            return null;
         }
 
         // Verify stock availability

--- a/src/main/java/org/csps/backend/service/impl/CartServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/CartServiceImpl.java
@@ -6,6 +6,7 @@ import org.csps.backend.exception.CartNotFoundException;
 import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.mapper.CartMapper;
 import org.csps.backend.repository.CartRepository;
+import org.csps.backend.service.CartItemService;
 import org.csps.backend.service.CartService;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ public class CartServiceImpl implements CartService {
 
     private final CartRepository cartRepository;
     private final CartMapper cartMapper;
+    private final CartItemService cartItemService;
 
     @Override
     public CartResponseDTO getCartByStudentId(String studentId) {
@@ -28,7 +30,9 @@ public class CartServiceImpl implements CartService {
         Cart cart = cartRepository.findByIdWithItems(studentId)
                 .orElseThrow(() -> new CartNotFoundException("Cart not found for student: " + studentId));
 
-        return cartMapper.toResponseDTO(cart);
+        CartResponseDTO response = cartMapper.toResponseDTO(cart);
+        response.setCartItemResponseDTOs(cartItemService.getCartItems(studentId));
+        return response;
     }
 
     @Override

--- a/src/main/java/org/csps/backend/service/impl/FinanceDashboardServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/FinanceDashboardServiceImpl.java
@@ -7,7 +7,6 @@ import java.time.format.TextStyle;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.csps.backend.domain.dtos.response.ChartDataDTO;
@@ -17,6 +16,9 @@ import org.csps.backend.domain.dtos.response.MembershipRatioDTO;
 import org.csps.backend.domain.dtos.response.OrderSummaryDTO;
 import org.csps.backend.domain.dtos.response.StudentMembershipDTO;
 import org.csps.backend.domain.entities.Order;
+import org.csps.backend.domain.entities.OrderItem;
+import org.csps.backend.domain.entities.StudentMembership;
+import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.repository.MerchVariantItemRepository;
 import org.csps.backend.repository.OrderItemRepository;
@@ -24,6 +26,7 @@ import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.repository.StudentMembershipRepository;
 import org.csps.backend.repository.StudentRepository;
 import org.csps.backend.service.FinanceDashboardService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -32,11 +35,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FinanceDashboardServiceImpl implements FinanceDashboardService {
 
+    private static final BigDecimal MEMBERSHIP_REVENUE_PER_MEMBER = BigDecimal.valueOf(100);
+    private static final List<OrderStatus> FINANCE_REVENUE_STATUSES =
+            List.of(OrderStatus.TO_BE_CLAIMED, OrderStatus.CLAIMED);
+
     private final MerchVariantItemRepository merchVariantItemRepository;
     private final OrderItemRepository orderItemRepository;
     private final StudentMembershipRepository studentMembershipRepository;
     private final StudentRepository studentRepository;
     private final OrderRepository orderRepository;
+
+    @Value("${csps.currentAcademicYear.start}")
+    private int currentYearStart;
+
+    @Value("${csps.currentAcademicYear.end}")
+    private int currentYearEnd;
 
     @Override
     public FinanceDashboardDTO getFinanceDashboardData() {
@@ -67,8 +80,11 @@ public class FinanceDashboardServiceImpl implements FinanceDashboardService {
     }
 
     private List<OrderSummaryDTO> getRecentOrders() {
-        // Get recent orders with CLAIMED status (paid/approved), limit 5
-        return orderItemRepository.findTop5ByOrderStatusInOrderByCreatedAtDesc(List.of(OrderStatus.CLAIMED)).stream()
+        return orderItemRepository
+                .findTop5ByOrderStatusInAndMerchVariantItemMerchVariantMerchMerchTypeNotOrderByCreatedAtDesc(
+                        FINANCE_REVENUE_STATUSES,
+                        MerchType.MEMBERSHIP)
+                .stream()
                 .map(item -> {
                     OrderSummaryDTO dto = new OrderSummaryDTO();
                     dto.setOrderItemId(item.getOrderItemId());
@@ -78,7 +94,7 @@ public class FinanceDashboardServiceImpl implements FinanceDashboardService {
                     dto.setProductName(item.getMerchVariantItem().getMerchVariant().getMerch().getMerchName());
                     dto.setS3ImageKey(item.getMerchVariantItem().getMerchVariant().getS3ImageKey());
                     dto.setStatus(item.getOrderStatus().name());
-                    dto.setPrice(BigDecimal.valueOf(item.getPriceAtPurchase()));
+                    dto.setPrice(calculateLineTotal(item));
                     dto.setCreatedAt(item.getCreatedAt());
                     return dto;
                 })
@@ -127,25 +143,28 @@ public class FinanceDashboardServiceImpl implements FinanceDashboardService {
         LocalDateTime startDateTime = startDate.atStartOfDay();
         LocalDateTime endDateTime = endDate.atTime(23, 59, 59);
 
-        // Only include CLAIMED (paid/approved) orders
-        List<Order> orders = orderRepository.findByOrderDateBetweenAndOrderStatus(startDateTime, endDateTime, OrderStatus.CLAIMED);
-
-        // Group orders by date
-        Map<LocalDate, List<Order>> ordersByDate = orders.stream()
-                .collect(Collectors.groupingBy(order -> order.getOrderDate().toLocalDate()));
+        List<Order> orders = orderRepository.findByOrderDateBetweenAndOrderStatusIn(
+                startDateTime,
+                endDateTime,
+                FINANCE_REVENUE_STATUSES);
+        List<StudentMembership> currentYearMemberships =
+                studentMembershipRepository.findByYearStartAndYearEnd(currentYearStart, currentYearEnd);
 
         List<String> days = startDate.datesUntil(endDate.plusDays(1))
                 .map(date -> date.getDayOfWeek().getDisplayName(TextStyle.SHORT, Locale.ENGLISH))
                 .collect(Collectors.toList());
 
         List<Integer> weeklyOrders = startDate.datesUntil(endDate.plusDays(1))
-                .map(date -> ordersByDate.getOrDefault(date, Collections.emptyList()).size())
+                .map(date -> (int) orders.stream()
+                        .filter(order -> order.getOrderDate() != null)
+                        .filter(order -> order.getOrderDate().toLocalDate().equals(date))
+                        .count())
                 .collect(Collectors.toList());
 
         List<Double> weeklyRevenue = startDate.datesUntil(endDate.plusDays(1))
-                .map(date -> ordersByDate.getOrDefault(date, Collections.emptyList()).stream()
-                        .mapToDouble(Order::getTotalPrice)
-                        .sum())
+                .map(date -> calculateMerchRevenueForDate(orders, date)
+                        .add(calculateMembershipRevenueForDate(currentYearMemberships, date))
+                        .doubleValue())
                 .collect(Collectors.toList());
 
         ChartDataDTO dto = new ChartDataDTO();
@@ -160,5 +179,57 @@ public class FinanceDashboardServiceImpl implements FinanceDashboardService {
         if (stock == null || stock <= 0) return "OUT_OF_STOCK";
         if (stock <= 10) return "LOW_STOCK";
         return "IN_STOCK";
+    }
+
+    private BigDecimal calculateMerchRevenueForDate(List<Order> orders, LocalDate targetDate) {
+        return orders.stream()
+                .filter(order -> order.getOrderDate() != null)
+                .filter(order -> order.getOrderDate().toLocalDate().equals(targetDate))
+                .map(this::calculateFinanceMerchRevenue)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private BigDecimal calculateMembershipRevenueForDate(List<StudentMembership> memberships, LocalDate targetDate) {
+        long membershipCount = memberships.stream()
+                .filter(membership -> membership.getDateJoined() != null)
+                .filter(membership -> membership.getDateJoined().toLocalDate().equals(targetDate))
+                .count();
+
+        return MEMBERSHIP_REVENUE_PER_MEMBER.multiply(BigDecimal.valueOf(membershipCount));
+    }
+
+    private BigDecimal calculateFinanceMerchRevenue(Order order) {
+        if (order == null || order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        return order.getOrderItems().stream()
+                .filter(this::isFinanceRevenueItem)
+                .filter(item -> !isMembershipItem(item))
+                .map(this::calculateLineTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private boolean isFinanceRevenueItem(OrderItem item) {
+        return item != null
+                && item.getOrderStatus() != null
+                && FINANCE_REVENUE_STATUSES.contains(item.getOrderStatus());
+    }
+
+    private boolean isMembershipItem(OrderItem item) {
+        return item != null
+                && item.getMerchVariantItem() != null
+                && item.getMerchVariantItem().getMerchVariant() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP;
+    }
+
+    private BigDecimal calculateLineTotal(OrderItem item) {
+        if (item == null || item.getPriceAtPurchase() == null || item.getQuantity() == null) {
+            return BigDecimal.ZERO;
+        }
+
+        return BigDecimal.valueOf(item.getPriceAtPurchase())
+                .multiply(BigDecimal.valueOf(item.getQuantity().longValue()));
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/MerchCustomerServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchCustomerServiceImpl.java
@@ -109,12 +109,29 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
     @Override
     @Transactional
     public List<OrderResponseDTO> recordBulkMerchPayment(BulkMerchPaymentRequestDTO requestDTO) {
+        if (requestDTO == null) {
+            throw new InvalidRequestException("Bulk merch payment request is required");
+        }
+
+        if (requestDTO.getEntries() == null || requestDTO.getEntries().isEmpty()) {
+            throw new InvalidRequestException("At least one bulk payment entry is required");
+        }
+
         /* validate MerchVariantItem exists with pessimistic write lock to prevent concurrent updates */
         MerchVariantItem merchVariantItem = merchVariantItemRepository.findByIdWithLock(requestDTO.getMerchVariantItemId())
                 .orElseThrow(() -> new MerchNotFoundException(
                         "MerchVariantItem not found with ID: " + requestDTO.getMerchVariantItemId()));
 
         int quantityPerStudent = requestDTO.getQuantity() != null ? requestDTO.getQuantity() : 1;
+        if (quantityPerStudent <= 0) {
+            throw new InvalidRequestException("Quantity must be greater than 0");
+        }
+
+        MerchType merchType = merchVariantItem.getMerchVariant().getMerch().getMerchType();
+        if (merchType == MerchType.MEMBERSHIP) {
+            throw new InvalidRequestException("Bulk merch payment does not support membership items. Use the membership payment flow.");
+        }
+
         double pricePerItem = merchVariantItem.getPrice();
 
         /* validate total stock upfront before any persistence */
@@ -139,7 +156,7 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
                         .orderDate(entry.getOrderDate())
                         .totalPrice(pricePerItem * quantityPerStudent)
                         .updatedAt(now)
-                        .orderStatus(OrderStatus.CLAIMED)
+                        .orderStatus(OrderStatus.TO_BE_CLAIMED)
                         .quantity(quantityPerStudent)
                         .build();
 

--- a/src/main/java/org/csps/backend/service/impl/MerchCustomerServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchCustomerServiceImpl.java
@@ -1,13 +1,16 @@
 package org.csps.backend.service.impl;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.csps.backend.domain.dtos.request.BulkMerchPaymentRequestDTO;
 import org.csps.backend.domain.dtos.request.BulkPaymentEntryDTO;
 import org.csps.backend.domain.dtos.response.MerchCustomerResponseDTO;
 import org.csps.backend.domain.dtos.response.OrderResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO;
 import org.csps.backend.domain.entities.MerchVariantItem;
 import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.entities.OrderItem;
@@ -25,6 +28,7 @@ import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.repository.StudentRepository;
 import org.csps.backend.service.MerchCustomerService;
+import org.csps.backend.service.TicketFreebieAssignmentService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -32,11 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-/**
- * Service implementation for merch-customer relationship operations.
- * Handles admin-facing queries: customer lookup, bulk payment recording,
- * and membership eligibility checks.
- */
 @Service
 @RequiredArgsConstructor
 public class MerchCustomerServiceImpl implements MerchCustomerService {
@@ -48,76 +47,48 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
     private final MerchRepository merchRepository;
     private final CartItemRepository cartItemRepository;
     private final OrderMapper orderMapper;
+    private final TicketFreebieAssignmentService ticketFreebieAssignmentService;
 
-    /**
-     * Retrieves a paginated list of customers (order items) who purchased a specific merch.
-     * Uses EntityGraph on the repository to eagerly load student profile, order, and merch details.
-     *
-     * @param merchId  the merch ID to look up customers for
-     * @param pageable pagination details (page, size, sort)
-     * @return paginated MerchCustomerResponseDTO with student and order details
-     */
     @Override
-    public Page<MerchCustomerResponseDTO> getCustomersByMerchId(Long merchId, Pageable pageable) {
+    public Page<MerchCustomerResponseDTO> getCustomersByMerchId(Long merchId, Pageable pageable, boolean includeFreebies) {
         validateMerchExists(merchId);
         Page<OrderItem> orderItems = orderItemRepository.findByMerchId(merchId, pageable);
-        return orderItems.map(this::mapToMerchCustomerDTO);
+        Map<Long, List<TicketFreebieAssignmentResponseDTO>> assignmentsByOrderItemId =
+                loadAssignments(orderItems.getContent(), includeFreebies);
+        return orderItems.map(orderItem -> mapToMerchCustomerDTO(
+                orderItem,
+                assignmentsByOrderItemId.get(orderItem.getOrderItemId()),
+                includeFreebies));
     }
 
-    /**
-     * Retrieves a paginated list of customers for a specific merch, filtered by order status.
-     * Useful for admins who want to see only PENDING, CLAIMED, etc. orders for a merch.
-     *
-     * @param merchId  the merch ID to look up
-     * @param status   the order status filter
-     * @param pageable pagination details
-     * @return filtered paginated MerchCustomerResponseDTO
-     */
     @Override
-    public Page<MerchCustomerResponseDTO> getCustomersByMerchIdAndStatus(Long merchId, OrderStatus status, Pageable pageable) {
+    public Page<MerchCustomerResponseDTO> getCustomersByMerchIdAndStatus(Long merchId, OrderStatus status, Pageable pageable, boolean includeFreebies) {
         validateMerchExists(merchId);
         Page<OrderItem> orderItems = orderItemRepository.findByMerchIdAndOrderStatus(merchId, status, pageable);
-        return orderItems.map(this::mapToMerchCustomerDTO);
+        Map<Long, List<TicketFreebieAssignmentResponseDTO>> assignmentsByOrderItemId =
+                loadAssignments(orderItems.getContent(), includeFreebies);
+        return orderItems.map(orderItem -> mapToMerchCustomerDTO(
+                orderItem,
+                assignmentsByOrderItemId.get(orderItem.getOrderItemId()),
+                includeFreebies));
     }
 
-    /**
-     * Returns total count of order items for a specific merch.
-     * Lightweight alternative to a full page request.
-     *
-     * @param merchId the merch ID to count for
-     * @return total number of order items
-     */
     @Override
-    public long getCustomerCountByMerchId(Long merchId) {
+    public long getCustomerCountByMerchId(Long merchId, boolean includeFreebies) {
         validateMerchExists(merchId);
         return orderItemRepository.countByMerchId(merchId);
     }
 
-    /**
-     * Batch-creates orders for multiple students who already paid for a specific merch.
-     * Each entry contains a studentId and the actual orderDate (preserving real purchase dates).
-     * Uses a batch-save approach: all Order and OrderItem entities are collected
-     * into temporary lists, then persisted in two bulk saveAll() calls instead
-     * of N+1 individual saves. Stock is decremented once at the end.
-     *
-     * @param requestDTO contains entries (studentId+orderDate pairs), merchVariantItemId, and quantity
-     * @return list of created OrderResponseDTOs (one per student)
-     * @throws StudentNotFoundException if any student ID is invalid
-     * @throws MerchNotFoundException   if the MerchVariantItem ID is invalid
-     * @throws InvalidRequestException  if stock is insufficient
-     */
     @Override
     @Transactional
     public List<OrderResponseDTO> recordBulkMerchPayment(BulkMerchPaymentRequestDTO requestDTO) {
         if (requestDTO == null) {
             throw new InvalidRequestException("Bulk merch payment request is required");
         }
-
         if (requestDTO.getEntries() == null || requestDTO.getEntries().isEmpty()) {
             throw new InvalidRequestException("At least one bulk payment entry is required");
         }
 
-        /* validate MerchVariantItem exists with pessimistic write lock to prevent concurrent updates */
         MerchVariantItem merchVariantItem = merchVariantItemRepository.findByIdWithLock(requestDTO.getMerchVariantItemId())
                 .orElseThrow(() -> new MerchNotFoundException(
                         "MerchVariantItem not found with ID: " + requestDTO.getMerchVariantItemId()));
@@ -128,13 +99,15 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
         }
 
         MerchType merchType = merchVariantItem.getMerchVariant().getMerch().getMerchType();
+        Long merchId = merchVariantItem.getMerchVariant().getMerch().getMerchId();
         if (merchType == MerchType.MEMBERSHIP) {
             throw new InvalidRequestException("Bulk merch payment does not support membership items. Use the membership payment flow.");
         }
+        if (merchType == MerchType.TICKET && quantityPerStudent > 1) {
+            throw new InvalidRequestException("Quantity for ticket items must remain 1");
+        }
 
         double pricePerItem = merchVariantItem.getPrice();
-
-        /* validate total stock upfront before any persistence */
         int totalStockNeeded = quantityPerStudent * requestDTO.getEntries().size();
         if (merchVariantItem.getStockQuantity() < totalStockNeeded) {
             throw new InvalidRequestException(
@@ -143,71 +116,65 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
         }
 
         try {
-            /* PHASE 1: Build all Order entities using each entry's actual orderDate */
-            List<Order> ordersToSave = new ArrayList<>();
+            List<Order> ordersToSave = new java.util.ArrayList<>();
+            List<Student> students = new java.util.ArrayList<>();
             LocalDateTime now = LocalDateTime.now();
+            Set<String> seenStudentIds = new LinkedHashSet<>();
 
             for (BulkPaymentEntryDTO entry : requestDTO.getEntries()) {
-                Student student = studentRepository.findByStudentId(entry.getStudentId())
-                        .orElseThrow(() -> new StudentNotFoundException("Student not found with ID: " + entry.getStudentId()));
+                String studentId = normalizeStudentId(entry);
+                if (!seenStudentIds.add(studentId)) {
+                    throw new InvalidRequestException("Duplicate student ID in bulk payment request: " + studentId);
+                }
+                if (merchType == MerchType.TICKET) {
+                    validateTicketBulkPaymentEligibility(studentId, merchId);
+                }
 
-                Order order = Order.builder()
+                Student student = studentRepository.findByStudentId(studentId)
+                        .orElseThrow(() -> new StudentNotFoundException("Student not found with ID: " + studentId));
+                students.add(student);
+
+                ordersToSave.add(Order.builder()
                         .student(student)
                         .orderDate(entry.getOrderDate())
                         .totalPrice(pricePerItem * quantityPerStudent)
                         .updatedAt(now)
                         .orderStatus(OrderStatus.TO_BE_CLAIMED)
                         .quantity(quantityPerStudent)
-                        .build();
-
-                ordersToSave.add(order);
+                        .build());
             }
 
-            /* PHASE 2: Batch-save all Orders in one round-trip */
             List<Order> savedOrders = orderRepository.saveAll(ordersToSave);
+            List<OrderItem> orderItemsToSave = new java.util.ArrayList<>();
 
-            /* PHASE 3: Build all OrderItem entities referencing their saved Orders */
-            List<OrderItem> orderItemsToSave = new ArrayList<>();
-
-            for (Order savedOrder : savedOrders) {
-                OrderItem orderItem = OrderItem.builder()
+            for (int index = 0; index < savedOrders.size(); index++) {
+                Order savedOrder = savedOrders.get(index);
+                orderItemsToSave.add(OrderItem.builder()
                         .order(savedOrder)
                         .merchVariantItem(merchVariantItem)
                         .quantity(quantityPerStudent)
                         .priceAtPurchase(pricePerItem)
                         .orderStatus(OrderStatus.TO_BE_CLAIMED)
-                        .build();
-
-                orderItemsToSave.add(orderItem);
+                        .build());
             }
 
-            /* PHASE 4: Batch-save all OrderItems in one round-trip */
-            orderItemRepository.saveAll(orderItemsToSave);
+            List<OrderItem> savedItems = orderItemRepository.saveAll(orderItemsToSave);
+            for (OrderItem savedItem : savedItems) {
+                if (savedItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.TICKET) {
+                    ticketFreebieAssignmentService.initializeAssignments(savedItem.getOrderItemId(), List.of());
+                }
+            }
 
-            /* PHASE 5: Decrement stock once and persist (pessimistic lock already held) */
             merchVariantItem.setStockQuantity(merchVariantItem.getStockQuantity() - totalStockNeeded);
             merchVariantItemRepository.save(merchVariantItem);
 
-            /* Map saved orders to response DTOs */
-            return savedOrders.stream()
-                    .map(orderMapper::toResponseDTO)
-                    .toList();
+            return savedOrders.stream().map(orderMapper::toResponseDTO).toList();
         } catch (Exception e) {
-            /* log error and rethrow to trigger transaction rollback */
-            System.err.println("Error recording bulk merch payment: " + e.getMessage());
-            e.printStackTrace();
-            throw new InvalidRequestException("Failed to record bulk merch payment: " + e.getMessage());
+            throw e instanceof InvalidRequestException ? (InvalidRequestException) e
+                : new InvalidRequestException("Failed to record bulk merch payment: " + e.getMessage());
         }
     }
 
-    /**
-     * Checks whether a student has a MEMBERSHIP merch type in their cart
-     * OR in any PENDING order. This combined check is used to determine
-     * whether to hide MEMBERSHIP merch from the store listing.
-     *
-     * @param studentId the student ID to check
-     * @return true if membership is already in cart or pending order
-     */
     @Override
     public boolean hasMembershipInCartOrPendingOrder(String studentId) {
         boolean inCart = cartItemRepository.existsByStudentIdAndMerchType(studentId, MerchType.MEMBERSHIP);
@@ -216,31 +183,24 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
         return inCart || inPendingOrder;
     }
 
-    /**
-     * Retrieves ALL customers (order items) for a specific merch without pagination.
-     * Useful for exporting the full customer list to CSV.
-     *
-     * @param merchId the merch ID to look up customers for
-     * @return complete list of MerchCustomerResponseDTO
-     */
     @Override
-    public List<MerchCustomerResponseDTO> getAllCustomersByMerchId(Long merchId) {
+    public List<MerchCustomerResponseDTO> getAllCustomersByMerchId(Long merchId, boolean includeFreebies) {
         validateMerchExists(merchId);
         List<OrderItem> orderItems = orderItemRepository.findAllByMerchId(merchId);
+        Map<Long, List<TicketFreebieAssignmentResponseDTO>> assignmentsByOrderItemId =
+                loadAssignments(orderItems, includeFreebies);
         return orderItems.stream()
-                .map(this::mapToMerchCustomerDTO)
+                .map(orderItem -> mapToMerchCustomerDTO(
+                        orderItem,
+                        assignmentsByOrderItemId.get(orderItem.getOrderItemId()),
+                        includeFreebies))
                 .toList();
     }
 
-    /**
-     * Maps an OrderItem entity to a MerchCustomerResponseDTO.
-     * Extracts student profile data, merch variant details, and order info
-     * into a flat DTO suitable for admin views.
-     *
-     * @param orderItem the order item entity to map
-     * @return populated MerchCustomerResponseDTO
-     */
-    private MerchCustomerResponseDTO mapToMerchCustomerDTO(OrderItem orderItem) {
+    private MerchCustomerResponseDTO mapToMerchCustomerDTO(
+            OrderItem orderItem,
+            List<TicketFreebieAssignmentResponseDTO> freebieAssignments,
+            boolean includeFreebies) {
         var order = orderItem.getOrder();
         var student = order.getStudent();
         var userProfile = student.getUserAccount().getUserProfile();
@@ -252,6 +212,7 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
                 + " " + (userProfile.getLastName() != null ? userProfile.getLastName() : "");
 
         return MerchCustomerResponseDTO.builder()
+                .orderItemId(orderItem.getOrderItemId())
                 .studentId(student.getStudentId())
                 .studentName(studentName.trim())
                 .yearLevel(student.getYearLevel())
@@ -264,15 +225,74 @@ public class MerchCustomerServiceImpl implements MerchCustomerService {
                 .orderStatus(orderItem.getOrderStatus())
                 .orderDate(order.getOrderDate())
                 .s3ImageKey(merchVariant.getS3ImageKey())
+                .hasFreebie(resolveHasFreebie(merchTypeOf(merch), merch, freebieAssignments, includeFreebies))
+                .freebieAssignments(includeFreebies ? defaultAssignments(freebieAssignments) : null)
                 .build();
     }
 
-    /**
-     * Validates that a Merch entity exists by its ID.
-     * Throws MerchNotFoundException if the merch doesn't exist.
-     *
-     * @param merchId the merch ID to validate
-     */
+    private Map<Long, List<TicketFreebieAssignmentResponseDTO>> loadAssignments(
+            List<OrderItem> orderItems,
+            boolean includeFreebies) {
+        if (!includeFreebies || orderItems == null || orderItems.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> orderItemIds = orderItems.stream()
+                .map(OrderItem::getOrderItemId)
+                .filter(id -> id != null)
+                .toList();
+        if (orderItemIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return ticketFreebieAssignmentService.getAssignmentsByOrderItemIds(orderItemIds);
+    }
+
+    private Boolean resolveHasFreebie(
+            MerchType merchType,
+            org.csps.backend.domain.entities.Merch merch,
+            List<TicketFreebieAssignmentResponseDTO> freebieAssignments,
+            boolean includeFreebies) {
+        if (!includeFreebies) {
+            return merchType == MerchType.TICKET && Boolean.TRUE.equals(merch.getHasFreebie());
+        }
+
+        return defaultAssignments(freebieAssignments).stream()
+                .anyMatch(assignment -> Boolean.TRUE.equals(assignment.getHasFreebie()));
+    }
+
+    private List<TicketFreebieAssignmentResponseDTO> defaultAssignments(
+            List<TicketFreebieAssignmentResponseDTO> freebieAssignments) {
+        return freebieAssignments == null ? List.of() : freebieAssignments;
+    }
+
+    private MerchType merchTypeOf(org.csps.backend.domain.entities.Merch merch) {
+        return merch == null ? null : merch.getMerchType();
+    }
+
+    private String normalizeStudentId(BulkPaymentEntryDTO entry) {
+        if (entry == null) {
+            throw new InvalidRequestException("Bulk payment entry is required");
+        }
+        if (entry.getStudentId() == null || entry.getStudentId().trim().isEmpty()) {
+            throw new InvalidRequestException("Student ID is required");
+        }
+        if (entry.getOrderDate() == null) {
+            throw new InvalidRequestException("Order date is required");
+        }
+        return entry.getStudentId().trim();
+    }
+
+    private void validateTicketBulkPaymentEligibility(String studentId, Long merchId) {
+        if (cartItemRepository.existsByStudentIdAndMerchId(studentId, merchId)
+                || orderItemRepository.existsByStudentIdAndMerchIdAndOrderStatusNotIn(
+                        studentId,
+                        merchId,
+                        List.of(OrderStatus.CANCELLED, OrderStatus.REJECTED))) {
+            throw new InvalidRequestException("Item is already in the cart / order");
+        }
+    }
+
     private void validateMerchExists(Long merchId) {
         if (!merchRepository.existsById(merchId)) {
             throw new MerchNotFoundException("Merch not found with ID: " + merchId);

--- a/src/main/java/org/csps/backend/service/impl/MerchServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchServiceImpl.java
@@ -1,4 +1,4 @@
- package org.csps.backend.service.impl;
+package org.csps.backend.service.impl;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,24 +26,19 @@ import org.csps.backend.service.MerchVariantItemService;
 import org.csps.backend.service.MerchVariantService;
 import org.csps.backend.service.S3Service;
 import org.csps.backend.service.StudentService;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
+import org.csps.backend.service.TicketFreebieConfigService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
-/**
- * Service implementation for Merch (base merchandise).
- * Manages merch creation, retrieval, and updates.
- * Delegates variant operations to MerchVariantService.
- * Delegates item-level (size/stock) operations to MerchVariantItemService.
- */
 @Service
 @RequiredArgsConstructor
 public class MerchServiceImpl implements MerchService {
+
+    private static final String ITEM_ALREADY_IN_CART_OR_ORDER = "Item is already in the cart / order";
 
     private final MerchRepository merchRepository;
     private final MerchMapper merchMapper;
@@ -54,7 +49,7 @@ public class MerchServiceImpl implements MerchService {
     private final CartItemRepository cartItemRepository;
     private final OrderItemRepository orderItemRepository;
     private final StudentService studentService;
-
+    private final TicketFreebieConfigService ticketFreebieConfigService;
 
     @Override
     @Transactional
@@ -68,7 +63,6 @@ public class MerchServiceImpl implements MerchService {
         String description = request.getDescription();
         Double basePrice = request.getBasePrice();
 
-        // Validate merch fields
         if (merchName == null || merchName.trim().isEmpty()) {
             throw new InvalidRequestException("Merchandise name is required");
         }
@@ -78,76 +72,48 @@ public class MerchServiceImpl implements MerchService {
         if (description == null || description.trim().isEmpty()) {
             throw new InvalidRequestException("Description is required");
         }
-
-        // Check duplicate name
+        if (basePrice == null || basePrice < 0) {
+            throw new InvalidRequestException("Base price is required and must be non-negative");
+        }
         if (merchRepository.existsByMerchName(merchName)) {
             throw new MerchAlreadyExistException("Merch name already exists");
         }
 
-        // PHASE 1: Create base Merch entity
         Merch merch = Merch.builder()
                 .merchName(merchName)
                 .description(description)
                 .merchType(merchType)
                 .basePrice(basePrice)
                 .s3ImageKey("placeholder")
+                .hasFreebie(Boolean.TRUE.equals(request.getHasFreebie()))
                 .build();
 
         Merch savedMerch = merchRepository.save(merch);
 
-        // Upload merch image if provided
+        validateAndPersistVariants(savedMerch.getMerchId(), merchType, request.getMerchVariantRequestDto());
+        ticketFreebieConfigService.syncConfigsForMerch(savedMerch, request.getHasFreebie(), request.getFreebieConfigs());
+
         if (request.getMerchImage() != null && !request.getMerchImage().isEmpty()) {
             String s3ImageKey = s3Service.uploadFile(request.getMerchImage(), savedMerch.getMerchId(), "merch");
             savedMerch.setS3ImageKey(s3ImageKey);
             savedMerch = merchRepository.save(savedMerch);
         }
-    
-        // PHASE 2 & 3: Process variants and items in batch
-        List<MerchVariantRequestDTO> variants = request.getMerchVariantRequestDto();
-        if (variants == null || variants.isEmpty()) {
-            throw new InvalidRequestException("At least one variant is required");
-        }
 
-        for (MerchVariantRequestDTO variantDto : variants) {
-            if(merchType == MerchType.CLOTHING) {
-                // For clothing, either color or design must be provided
-                if ((variantDto.getColor() == null || variantDto.getColor().trim().isEmpty())
-                    && (variantDto.getDesign() == null || variantDto.getDesign().trim().isEmpty())) {
-                    throw new InvalidRequestException("Either color or design is required for clothing variants");
-                }
-            } else {
-                // For non-clothing, design is required
-                if (variantDto.getDesign() == null || variantDto.getDesign().trim().isEmpty()) {
-                    throw new InvalidRequestException("Design is required for non-clothing variants");
-                }
-            }
-
-            // Validate items
-            List<MerchVariantItemRequestDTO> items = variantDto.getVariantItems();
-            if (items == null || items.isEmpty()) {
-                throw new InvalidRequestException("At least one item (size/price/stock) is required for each variant");
-            }
-
-            // Create variant with items passed directly (all saved in batch within service)
-            merchVariantService.addVariantToMerch(savedMerch.getMerchId(), variantDto);
-        }
-
-        // Reload merch with all variants and items, then build complete response
         Merch finalMerch = merchRepository.findById(savedMerch.getMerchId())
                 .orElseThrow(() -> new MerchNotFoundException("Merch not found"));
-
-        return merchMapper.toDetailedResponseDTO(finalMerch);
+        return enrichDetailedResponse(merchMapper.toDetailedResponseDTO(finalMerch));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<MerchDetailedResponseDTO> getAllMerch() {
         List<MerchDetailedResponseDTO> allMerch = merchRepository.findAll().stream()
                 .map(merchMapper::toDetailedResponseDTO)
+                .map(this::enrichDetailedResponse)
                 .collect(Collectors.toList());
 
         String studentId = studentService.getCurrentStudentId();
         if (studentId != null) {
-            // combine membership checks: active membership, in cart, or in pending order
             boolean shouldExcludeMembership = studentMembershipRepository.hasActiveMembership(studentId)
                     || cartItemRepository.existsByStudentIdAndMerchType(studentId, MerchType.MEMBERSHIP)
                     || orderItemRepository.existsByStudentIdAndMerchTypeAndStatus(studentId, MerchType.MEMBERSHIP, OrderStatus.PENDING);
@@ -160,13 +126,15 @@ public class MerchServiceImpl implements MerchService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<MerchSummaryResponseDTO> getAllMerchSummaries() {
-        List<MerchSummaryResponseDTO> summaries = merchRepository.findAllSummaries();
+        List<MerchSummaryResponseDTO> summaries = merchRepository.findAllSummaries().stream()
+            .map(this::enrichSummaryResponse)
+            .toList();
+
         String studentId = studentService.getCurrentStudentId();
-        
         if (studentId != null) {
-            // combine membership checks: active membership, in cart, or in pending order
-            boolean shouldExcludeMembership = studentMembershipRepository.hasActiveMembership(studentId) 
+            boolean shouldExcludeMembership = studentMembershipRepository.hasActiveMembership(studentId)
                     || cartItemRepository.existsByStudentIdAndMerchType(studentId, MerchType.MEMBERSHIP)
                     || orderItemRepository.existsByStudentIdAndMerchTypeAndStatus(studentId, MerchType.MEMBERSHIP, OrderStatus.PENDING);
 
@@ -180,13 +148,15 @@ public class MerchServiceImpl implements MerchService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public MerchDetailedResponseDTO getMerchById(Long id) {
         Merch merch = merchRepository.findById(id)
                 .orElseThrow(() -> new MerchNotFoundException("Merch not found with id: " + id));
-        return merchMapper.toDetailedResponseDTO(merch);
+        return enrichDetailedResponse(merchMapper.toDetailedResponseDTO(merch));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<MerchSummaryResponseDTO> getMerchByType(MerchType merchType) {
         if (merchType == null) {
             throw new InvalidRequestException("Merch type is required");
@@ -194,100 +164,95 @@ public class MerchServiceImpl implements MerchService {
 
         String studentId = studentService.getCurrentStudentId();
         if (studentId != null && merchType == MerchType.MEMBERSHIP) {
-            // combine membership checks: active membership, in cart, or in pending order
             boolean shouldExcludeMembership = studentMembershipRepository.hasActiveMembership(studentId)
                     || cartItemRepository.existsByStudentIdAndMerchType(studentId, MerchType.MEMBERSHIP)
                     || orderItemRepository.existsByStudentIdAndMerchTypeAndStatus(studentId, MerchType.MEMBERSHIP, OrderStatus.PENDING);
-            
             if (shouldExcludeMembership) {
                 return List.of();
             }
         }
 
-        return merchRepository.findAllSummaryByType(merchType);
+        return merchRepository.findAllSummaryByType(merchType).stream()
+            .map(this::enrichSummaryResponse)
+            .toList();
     }
 
     @Override
     @Transactional
-    public MerchDetailedResponseDTO putMerch(Long merchId, MerchUpdateRequestDTO merchUpdateRequestDTO) throws IOException {
-        // Find merch by ID
+    public MerchDetailedResponseDTO putMerch(Long merchId, MerchUpdateRequestDTO request) throws IOException {
         Merch foundMerch = merchRepository.findById(merchId)
                 .orElseThrow(() -> new MerchNotFoundException("Merch not found with id: " + merchId));
 
-        // Validate required fields
-        if (merchUpdateRequestDTO.getMerchName() == null || merchUpdateRequestDTO.getMerchName().trim().isEmpty()
-            || merchUpdateRequestDTO.getDescription() == null || merchUpdateRequestDTO.getDescription().trim().isEmpty()
-            || merchUpdateRequestDTO.getMerchType() == null) {
-            throw new InvalidRequestException("Invalid credential");
+        if (request.getMerchName() == null || request.getMerchName().trim().isEmpty()
+            || request.getDescription() == null || request.getDescription().trim().isEmpty()
+            || request.getMerchType() == null) {
+            throw new InvalidRequestException("Merch name, description, and type are required");
         }
 
-        // Check for duplicate name (excluding current merch)
-        if (!foundMerch.getMerchName().equals(merchUpdateRequestDTO.getMerchName())
-            && merchRepository.existsByMerchName(merchUpdateRequestDTO.getMerchName())) {
+        if (!foundMerch.getMerchName().equals(request.getMerchName())
+            && merchRepository.existsByMerchName(request.getMerchName())) {
             throw new MerchAlreadyExistException("Merch name already exists");
         }
 
-        // Update fields
-        foundMerch.setMerchName(merchUpdateRequestDTO.getMerchName());
-        foundMerch.setDescription(merchUpdateRequestDTO.getDescription());
-        foundMerch.setMerchType(merchUpdateRequestDTO.getMerchType());
+        foundMerch.setMerchName(request.getMerchName().trim());
+        foundMerch.setDescription(request.getDescription().trim());
+        foundMerch.setMerchType(request.getMerchType());
+        foundMerch.setHasFreebie(Boolean.TRUE.equals(request.getHasFreebie()));
 
         Merch updated = merchRepository.save(foundMerch);
-        return merchMapper.toDetailedResponseDTO(updated);
+        ticketFreebieConfigService.syncConfigsForMerch(updated, request.getHasFreebie(), request.getFreebieConfigs());
+        return enrichDetailedResponse(merchMapper.toDetailedResponseDTO(updated));
     }
 
     @Override
     @Transactional
-    public MerchDetailedResponseDTO patchMerch(Long merchId, MerchUpdateRequestDTO merchUpdateRequestDTO) throws IOException {
-        // Find merch by ID
+    public MerchDetailedResponseDTO patchMerch(Long merchId, MerchUpdateRequestDTO request) throws IOException {
         Merch foundMerch = merchRepository.findById(merchId)
                 .orElseThrow(() -> new MerchNotFoundException("Merch not found with id: " + merchId));
 
-        // Partial updates
-        if (merchUpdateRequestDTO.getMerchName() != null && !merchUpdateRequestDTO.getMerchName().trim().isEmpty()) {
-            if (!foundMerch.getMerchName().equals(merchUpdateRequestDTO.getMerchName())
-                && merchRepository.existsByMerchName(merchUpdateRequestDTO.getMerchName())) {
+        if (request.getMerchName() != null && !request.getMerchName().trim().isEmpty()) {
+            if (!foundMerch.getMerchName().equals(request.getMerchName())
+                && merchRepository.existsByMerchName(request.getMerchName())) {
                 throw new MerchAlreadyExistException("Merch name already exists");
             }
-            foundMerch.setMerchName(merchUpdateRequestDTO.getMerchName());
+            foundMerch.setMerchName(request.getMerchName().trim());
         }
-        if (merchUpdateRequestDTO.getDescription() != null && !merchUpdateRequestDTO.getDescription().trim().isEmpty()) {
-            foundMerch.setDescription(merchUpdateRequestDTO.getDescription());
+        if (request.getDescription() != null && !request.getDescription().trim().isEmpty()) {
+            foundMerch.setDescription(request.getDescription().trim());
         }
-        if (merchUpdateRequestDTO.getMerchType() != null) {
-            foundMerch.setMerchType(merchUpdateRequestDTO.getMerchType());
+        if (request.getMerchType() != null) {
+            foundMerch.setMerchType(request.getMerchType());
+        }
+        if (request.getHasFreebie() != null) {
+            foundMerch.setHasFreebie(request.getHasFreebie());
         }
 
         Merch updated = merchRepository.save(foundMerch);
-        return merchMapper.toDetailedResponseDTO(updated);    
+        ticketFreebieConfigService.syncConfigsForMerch(updated, updated.getHasFreebie(), request.getFreebieConfigs());
+        return enrichDetailedResponse(merchMapper.toDetailedResponseDTO(updated));
     }
 
     @Override
     @Transactional
     public void deleteMerch(Long merchId) {
-        // Find merch by ID
         Merch merch = merchRepository.findById(merchId)
                 .orElseThrow(() -> new MerchNotFoundException("Merch not found with id: " + merchId));
-
-        // soft delete: mark as inactive instead of hard delete
         merch.setIsActive(false);
         merchRepository.save(merch);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Page<MerchDetailedResponseDTO> getArchivedMerch(Pageable pageable) {
-        /* retrieve archived merch paginated with eager loading of variants */
         Page<Merch> archivedMerch = merchRepository.findArchivedMerch(pageable);
-        return archivedMerch.map(merchMapper::toDetailedResponseDTO);
+        return archivedMerch.map(merchMapper::toDetailedResponseDTO).map(this::enrichDetailedResponse);
     }
 
     @Override
     @Transactional
     public MerchDetailedResponseDTO revertMerch(Long merchId) {
-        /* revert archived merch back to active status */
         Merch merch = merchRepository.findByIdAndIsInactive(merchId)
                 .orElseThrow(() -> new MerchNotFoundException("Archived merch not found with id: " + merchId));
-        
 
         if (merch.getIsActive()) {
             throw new InvalidRequestException("Merch with id " + merchId + " is already active");
@@ -295,6 +260,93 @@ public class MerchServiceImpl implements MerchService {
 
         merch.setIsActive(true);
         Merch reverted = merchRepository.save(merch);
-        return merchMapper.toDetailedResponseDTO(reverted);
+        return enrichDetailedResponse(merchMapper.toDetailedResponseDTO(reverted));
+    }
+
+    private void validateAndPersistVariants(Long merchId, MerchType merchType, List<MerchVariantRequestDTO> variants) throws IOException {
+        if (variants == null || variants.isEmpty()) {
+            throw new InvalidRequestException("At least one variant is required");
+        }
+
+        for (MerchVariantRequestDTO variantDto : variants) {
+            validateVariantRequest(merchType, variantDto);
+        }
+
+        for (MerchVariantRequestDTO variantDto : variants) {
+            merchVariantService.addVariantToMerch(merchId, variantDto);
+        }
+    }
+
+    private void validateVariantRequest(MerchType merchType, MerchVariantRequestDTO variantDto) {
+        if (variantDto == null) {
+            throw new InvalidRequestException("Variant request is required");
+        }
+
+        if (merchType == MerchType.CLOTHING) {
+            if (variantDto.getColor() == null || variantDto.getColor().trim().isEmpty()) {
+                throw new InvalidRequestException("Color is required for clothing variants");
+            }
+            if (variantDto.getDesign() != null && !variantDto.getDesign().trim().isEmpty()) {
+                throw new InvalidRequestException("Design is not allowed for clothing variants");
+            }
+        } else {
+            if (variantDto.getDesign() == null || variantDto.getDesign().trim().isEmpty()) {
+                throw new InvalidRequestException("Design is required for non-clothing variants");
+            }
+            if (variantDto.getColor() != null && !variantDto.getColor().trim().isEmpty()) {
+                throw new InvalidRequestException("Color is not allowed for non-clothing variants");
+            }
+        }
+
+        List<MerchVariantItemRequestDTO> items = variantDto.getVariantItems();
+        if (items == null || items.isEmpty()) {
+            throw new InvalidRequestException("At least one item (size/price/stock) is required for each variant");
+        }
+    }
+
+    private MerchDetailedResponseDTO enrichDetailedResponse(MerchDetailedResponseDTO response) {
+        response.setFreebieConfigs(ticketFreebieConfigService.getConfigsByTicketMerchId(response.getMerchId()));
+        enrichPurchaseState(response.getMerchId(), response.getMerchType(), response::setPurchaseBlocked, response::setPurchaseBlockMessage);
+        return response;
+    }
+
+    private MerchSummaryResponseDTO enrichSummaryResponse(MerchSummaryResponseDTO response) {
+        response.setFreebieConfigs(ticketFreebieConfigService.getConfigsByTicketMerchId(response.getMerchId()));
+        enrichPurchaseState(response.getMerchId(), response.getMerchType(), response::setPurchaseBlocked, response::setPurchaseBlockMessage);
+        return response;
+    }
+
+    private void enrichPurchaseState(
+            Long merchId,
+            MerchType merchType,
+            java.util.function.Consumer<Boolean> purchaseBlockedConsumer,
+            java.util.function.Consumer<String> purchaseBlockMessageConsumer) {
+        String studentId = studentService.getCurrentStudentId();
+        if (studentId == null || merchType == null) {
+            purchaseBlockedConsumer.accept(Boolean.FALSE);
+            purchaseBlockMessageConsumer.accept(null);
+            return;
+        }
+
+        boolean purchaseBlocked = false;
+        String purchaseBlockMessage = null;
+
+        if (merchType == MerchType.TICKET) {
+            purchaseBlocked = cartItemRepository.existsByStudentIdAndMerchId(studentId, merchId)
+                    || orderItemRepository.existsByStudentIdAndMerchIdAndOrderStatusNotIn(
+                            studentId,
+                            merchId,
+                            List.of(OrderStatus.CANCELLED, OrderStatus.REJECTED));
+            purchaseBlockMessage = purchaseBlocked ? ITEM_ALREADY_IN_CART_OR_ORDER : null;
+        } else if (merchType == MerchType.MEMBERSHIP) {
+            boolean hasMembershipConflict = studentMembershipRepository.hasActiveMembership(studentId)
+                    || cartItemRepository.existsByStudentIdAndMerchType(studentId, MerchType.MEMBERSHIP)
+                    || orderItemRepository.existsByStudentIdAndMerchTypeAndStatus(studentId, MerchType.MEMBERSHIP, OrderStatus.PENDING);
+            purchaseBlocked = hasMembershipConflict;
+            purchaseBlockMessage = hasMembershipConflict ? ITEM_ALREADY_IN_CART_OR_ORDER : null;
+        }
+
+        purchaseBlockedConsumer.accept(purchaseBlocked);
+        purchaseBlockMessageConsumer.accept(purchaseBlockMessage);
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/MerchVariantItemServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchVariantItemServiceImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.csps.backend.domain.dtos.request.MerchVariantItemRequestDTO;
 import org.csps.backend.domain.dtos.response.MerchVariantItemResponseDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
 import org.csps.backend.domain.entities.Merch;
 import org.csps.backend.domain.entities.MerchVariant;
 import org.csps.backend.domain.entities.MerchVariantItem;
@@ -13,9 +14,12 @@ import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.exception.MerchVariantNotFoundException;
 import org.csps.backend.mapper.MerchVariantItemMapper;
+import org.csps.backend.repository.CartItemRepository;
 import org.csps.backend.repository.MerchVariantItemRepository;
 import org.csps.backend.repository.MerchVariantRepository;
+import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.service.MerchVariantItemService;
+import org.csps.backend.service.TicketFreebieConfigService;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +33,9 @@ public class MerchVariantItemServiceImpl implements MerchVariantItemService {
     private final MerchVariantItemRepository itemRepository;
     private final MerchVariantRepository variantRepository;
     private final MerchVariantItemMapper itemMapper;
+    private final TicketFreebieConfigService ticketFreebieConfigService;
+    private final CartItemRepository cartItemRepository;
+    private final OrderItemRepository orderItemRepository;
 
     @Override
     @Transactional
@@ -135,6 +142,7 @@ public class MerchVariantItemServiceImpl implements MerchVariantItemService {
                 if (existingSizesSet.contains(dto.getSize())) {
                     throw new InvalidRequestException("Item with size " + dto.getSize() + " already exists for this variant");
                 }
+                existingSizesSet.add(dto.getSize());
             } else {
                 // For non-clothing (PIN, STICKER, KEYCHAIN, etc): size NOT allowed, must use design
                 if (dto.getSize() != null) {
@@ -223,10 +231,17 @@ public class MerchVariantItemServiceImpl implements MerchVariantItemService {
     @Override
     @Transactional
     public void deleteItem(Long merchVariantItemId) {
-        if (!itemRepository.existsById(merchVariantItemId)) {
-            throw new InvalidRequestException("MerchVariantItem not found with id: " + merchVariantItemId);
+        MerchVariantItem item = itemRepository.findById(merchVariantItemId)
+                .orElseThrow(() -> new InvalidRequestException("MerchVariantItem not found with id: " + merchVariantItemId));
+
+        if (cartItemRepository.existsByMerchVariantItemMerchVariantItemId(merchVariantItemId)) {
+            throw new InvalidRequestException("Cannot delete item that is referenced by cart items");
         }
-        itemRepository.deleteById(merchVariantItemId);
+        if (orderItemRepository.existsByMerchVariantItemMerchVariantItemId(merchVariantItemId)) {
+            throw new InvalidRequestException("Cannot delete item that is referenced by order items");
+        }
+
+        itemRepository.delete(item);
     }
 
     @Override
@@ -235,5 +250,10 @@ public class MerchVariantItemServiceImpl implements MerchVariantItemService {
                 .orElseThrow(() -> new InvalidRequestException("MerchVariantItem not found with id: " + merchVariantItemId));
 
         return itemMapper.toResponseDto(item);
+    }
+
+    @Override
+    public List<TicketFreebieConfigResponseDTO> getFreebiesByMerchVariantItemId(Long merchVariantItemId) {
+        return ticketFreebieConfigService.getConfigsByMerchVariantItemId(merchVariantItemId);
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/MerchVariantServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/MerchVariantServiceImpl.java
@@ -13,6 +13,7 @@ import org.csps.backend.exception.MerchNotFoundException;
 import org.csps.backend.exception.MerchVariantAlreadyExisted;
 import org.csps.backend.exception.MerchVariantNotFoundException;
 import org.csps.backend.mapper.MerchVariantMapper;
+import org.csps.backend.repository.CartItemRepository;
 import org.csps.backend.repository.MerchRepository;
 import org.csps.backend.repository.MerchVariantRepository;
 import org.csps.backend.repository.OrderItemRepository;
@@ -37,7 +38,7 @@ public class MerchVariantServiceImpl implements MerchVariantService {
     private final MerchVariantMapper merchVariantMapper;
     private final MerchRepository merchRepository;
     private final OrderItemRepository orderItemRepository;
-    
+    private final CartItemRepository cartItemRepository;
     private final S3Service s3Service;
     private final MerchVariantItemService merchVariantItemService;
 
@@ -61,8 +62,11 @@ public class MerchVariantServiceImpl implements MerchVariantService {
                 if (dto.getColor() == null || dto.getColor().trim().isEmpty()) {
                     throw new InvalidRequestException("color is required for clothing variants");
                 }
+                if (dto.getDesign() != null && !dto.getDesign().trim().isEmpty()) {
+                    throw new InvalidRequestException("design is not allowed for clothing variants");
+                }
             
-                if (merchVariantRepository.existsByMerchMerchIdAndColor(merchId, dto.getColor())) {
+                if (merchVariantRepository.existsByMerchMerchIdAndColor(merchId, dto.getColor().trim())) {
                     throw new MerchVariantAlreadyExisted("Variant with color " + dto.getColor() + " already exists");
                 }
             }
@@ -71,7 +75,10 @@ public class MerchVariantServiceImpl implements MerchVariantService {
                 if (dto.getDesign() == null || dto.getDesign().trim().isEmpty()) {
                     throw new InvalidRequestException("design is required for this merch type");
                 }
-                if (merchVariantRepository.existsByMerchMerchIdAndDesign(merchId, dto.getDesign())) {
+                if (dto.getColor() != null && !dto.getColor().trim().isEmpty()) {
+                    throw new InvalidRequestException("color is not allowed for this merch type");
+                }
+                if (merchVariantRepository.existsByMerchMerchIdAndDesign(merchId, dto.getDesign().trim())) {
                     throw new MerchVariantAlreadyExisted("Variant with design " + dto.getDesign() + " already exists");
                 }
             }
@@ -89,17 +96,16 @@ public class MerchVariantServiceImpl implements MerchVariantService {
         // Save variant once (before image upload so we have ID for S3 path)
         MerchVariant saved = merchVariantRepository.save(variant);
 
-        // Upload variant image and update S3 key if provided
-        if (dto.getVariantImage() != null && !dto.getVariantImage().isEmpty()) {
-            String s3ImageKey = s3Service.uploadFile(dto.getVariantImage(), saved.getMerchVariantId(), "merchVariant");
-            saved.setS3ImageKey(s3ImageKey);
-            // Update with new S3 key in single save
-            saved = merchVariantRepository.save(saved);
-        }
-
         // Add items if provided (batch save handled in service)
         if (dto.getVariantItems() != null && !dto.getVariantItems().isEmpty()) {
             merchVariantItemService.addMultipleItemsToVariant(saved.getMerchVariantId(), dto.getVariantItems());
+        }
+
+        // Upload the image only after variant item validation/persistence succeeds.
+        if (dto.getVariantImage() != null && !dto.getVariantImage().isEmpty()) {
+            String s3ImageKey = s3Service.uploadFile(dto.getVariantImage(), saved.getMerchVariantId(), "merchVariant");
+            saved.setS3ImageKey(s3ImageKey);
+            saved = merchVariantRepository.save(saved);
         }
 
         return merchVariantMapper.toResponseDTO(saved);
@@ -179,25 +185,23 @@ public class MerchVariantServiceImpl implements MerchVariantService {
     @Override
     @Transactional
     public void deleteVariant(Long merchVariantId) {
-        // Verify variant exists
         MerchVariant variant = merchVariantRepository.findById(merchVariantId)
                 .orElseThrow(() -> new MerchVariantNotFoundException("MerchVariant not found with id: " + merchVariantId));
-
-        /* check if variant items are in any orders; prevent deletion if in use */
+        
+        if (cartItemRepository.existsByMerchVariantItemMerchVariantMerchVariantId(merchVariantId)) {
+            throw new InvalidRequestException("Cannot delete variant that has items in carts");
+        }
         if (orderItemRepository.existsByMerchVariantItemMerchVariantMerchVariantId(merchVariantId)) {
             throw new InvalidRequestException("Cannot delete variant that has items in orders");
         }
         
         merchVariantRepository.delete(variant);
 
-        // Delete S3 image if not placeholder
         if (variant.getS3ImageKey() != null 
             && !variant.getS3ImageKey().isEmpty() 
             && !variant.getS3ImageKey().equals("placeholder")) {
             s3Service.deleteFile(variant.getS3ImageKey());
-            // Delete variant (cascades to items)
         }
-
     }
 
 }

--- a/src/main/java/org/csps/backend/service/impl/OrderItemServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/OrderItemServiceImpl.java
@@ -4,10 +4,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.csps.backend.domain.dtos.request.OrderItemRequestDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieAssignmentRequestDTO;
 import org.csps.backend.domain.dtos.response.OrderItemResponseDTO;
 import org.csps.backend.domain.entities.MerchVariantItem;
 import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.entities.OrderItem;
+import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.exception.InvalidOrderStatusTransitionException;
 import org.csps.backend.exception.InvalidRequestException;
@@ -17,9 +19,12 @@ import org.csps.backend.mapper.OrderItemMapper;
 import org.csps.backend.repository.MerchVariantItemRepository;
 import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
+import org.csps.backend.repository.TicketFreebieAssignmentRepository;
 import org.csps.backend.service.OrderItemService;
 import org.csps.backend.service.OrderLifecycleService;
 import org.csps.backend.service.OrderNotificationService;
+import org.csps.backend.service.StudentMembershipService;
+import org.csps.backend.service.TicketFreebieAssignmentService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -30,49 +35,47 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class OrderItemServiceImpl implements OrderItemService {
-    
+
+    private static final String ITEM_ALREADY_IN_CART_OR_ORDER = "Item is already in the cart / order";
+
     private final OrderItemRepository orderItemRepository;
     private final OrderRepository orderRepository;
     private final MerchVariantItemRepository merchVariantItemRepository;
     private final OrderItemMapper orderItemMapper;
     private final OrderNotificationService orderNotificationService;
     private final OrderLifecycleService orderLifecycleService;
-    
+    private final TicketFreebieAssignmentService ticketFreebieAssignmentService;
+    private final TicketFreebieAssignmentRepository ticketFreebieAssignmentRepository;
+    private final StudentMembershipService studentMembershipService;
+
     @Override
     @Transactional
     public OrderItemResponseDTO createOrderItem(OrderItemRequestDTO orderItemRequestDTO) {
         if (orderItemRequestDTO == null) {
             throw new InvalidRequestException("Order item request is required");
         }
-        
-        /* validate order exists */
+
         Order order = orderRepository.findById(orderItemRequestDTO.getOrderId())
             .orElseThrow(() -> new OrderNotFoundException("Order not found"));
-        
-        /* validate merch variant item exists and acquire pessimistic write lock to prevent concurrent stock updates */
+
         MerchVariantItem merchVariantItem = merchVariantItemRepository.findByIdWithLock(orderItemRequestDTO.getMerchVariantItemId())
-            .orElseThrow(() -> new InvalidRequestException("MerchVariantItem not found"));
-        
-        /* extract merchVariantId from MerchVariantItem */
-        
-        /* validate quantity */
+                .orElseThrow(() -> new InvalidRequestException("MerchVariantItem not found"));
+
         if (orderItemRequestDTO.getQuantity() == null || orderItemRequestDTO.getQuantity() <= 0) {
             throw new InvalidRequestException("Quantity must be greater than 0");
         }
-        
-        /* validate sufficient stock */
         if (orderItemRequestDTO.getQuantity() > merchVariantItem.getStockQuantity()) {
-            throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity() + 
-                    ", Requested: " + orderItemRequestDTO.getQuantity());
+            throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity()
+                    + ", Requested: " + orderItemRequestDTO.getQuantity());
         }
 
         Double priceSnapshot = merchVariantItem.getPrice();
         if (priceSnapshot == null || priceSnapshot < 0) {
             throw new InvalidRequestException("MerchVariantItem price must be configured before creating an order item");
         }
-        
+        validateTicketPurchaseEligibility(order, merchVariantItem);
+
         try {
-            /* snapshot the current SKU price on the server to prevent client-side tampering */
             OrderItem orderItem = OrderItem.builder()
                 .order(order)
                 .merchVariantItem(merchVariantItem)
@@ -80,38 +83,28 @@ public class OrderItemServiceImpl implements OrderItemService {
                 .priceAtPurchase(priceSnapshot)
                 .updatedAt(LocalDateTime.now())
                 .build();
-            
+
             OrderItem savedOrderItem = orderItemRepository.save(orderItem);
-            
-            /* deduct stock from MerchVariantItem (pessimistic lock already held) */
-            /* stock is reserved when order item is created */
-            int newStockQuantity = merchVariantItem.getStockQuantity() - orderItemRequestDTO.getQuantity();
-            merchVariantItem.setStockQuantity(newStockQuantity);
+
+            merchVariantItem.setStockQuantity(merchVariantItem.getStockQuantity() - orderItemRequestDTO.getQuantity());
             merchVariantItemRepository.save(merchVariantItem);
-            
-            System.out.println("Order item created successfully. Stock deducted: " + orderItemRequestDTO.getQuantity());
-            return orderItemMapper.toResponseDTO(savedOrderItem);
+
+            if (merchVariantItem.getMerchVariant() != null
+                && merchVariantItem.getMerchVariant().getMerch() != null
+                && merchVariantItem.getMerchVariant().getMerch().getMerchType() == MerchType.TICKET) {
+                ticketFreebieAssignmentService.initializeAssignments(
+                    savedOrderItem.getOrderItemId(),
+                    resolveAssignmentRequests(orderItemRequestDTO)
+                );
+            }
+
+            return enrichResponse(orderItemMapper.toResponseDTO(savedOrderItem));
         } catch (Exception e) {
-            /* log error and rethrow to trigger transaction rollback */
-            System.err.println("Error creating order item and deducting stock: " + e.getMessage());
-            e.printStackTrace();
-            throw new InvalidRequestException("Failed to create order item: " + e.getMessage());
+            throw e instanceof InvalidRequestException ? (InvalidRequestException) e
+                : new InvalidRequestException("Failed to create order item: " + e.getMessage());
         }
     }
-    
-    /**
-     * Helper method to extract MerchVariantId from MerchVariantItem
-     */
-    private Long getMerchVariantIdFromItem(MerchVariantItem merchVariantItem) {
-        if (merchVariantItem == null) {
-            throw new InvalidRequestException("MerchVariantItem is null");
-        }
-        if (merchVariantItem.getMerchVariant() == null) {
-            throw new InvalidRequestException("MerchVariant is null for MerchVariantItem");
-        }
-        return merchVariantItem.getMerchVariant().getMerchVariantId();
-    }
-    
+
     @Override
     public OrderItemResponseDTO getOrderItemById(Long id, String studentId) {
         if (id == null || id <= 0) {
@@ -124,23 +117,22 @@ public class OrderItemServiceImpl implements OrderItemService {
                 .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"))
             : orderItemRepository.findByOrderItemIdAndOrderStudentStudentId(id, studentScope)
                 .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
-        
-        return orderItemMapper.toResponseDTO(orderItem);
+
+        return enrichResponse(orderItemMapper.toResponseDTO(orderItem));
     }
-    
+
     @Override
     public Page<OrderItemResponseDTO> getOrderItemsByStatus(OrderStatus status, Pageable pageable, String studentId) {
         if (status == null) {
             throw new InvalidRequestException("Order status is required");
         }
-        
+
         String studentScope = normalizeStudentScope(studentId);
         Page<OrderItem> orderItems = studentScope == null
             ? orderItemRepository.findByOrderStatusOrderByUpdatedAtDesc(status, pageable)
             : orderItemRepository.findByOrderStatusAndOrderStudentStudentId(status, studentScope, pageable);
 
-        return orderItems.map(orderItemMapper::toResponseDTO);
-
+        return orderItems.map(orderItemMapper::toResponseDTO).map(this::enrichResponse);
     }
 
     @Override
@@ -158,9 +150,10 @@ public class OrderItemServiceImpl implements OrderItemService {
 
         return orderItems.stream()
             .map(orderItemMapper::toResponseDTO)
+            .map(this::enrichResponse)
             .toList();
     }
-    
+
     @Override
     public Page<OrderItemResponseDTO> getOrderItemsByOrderIdPaginated(Long orderId, Pageable pageable, String studentId) {
         if (orderId == null || orderId <= 0) {
@@ -174,17 +167,17 @@ public class OrderItemServiceImpl implements OrderItemService {
             ? orderItemRepository.findByOrderOrderId(orderId, pageable)
             : orderItemRepository.findByOrderOrderIdAndOrderStudentStudentId(orderId, studentScope, pageable);
 
-        return orderItems.map(orderItemMapper::toResponseDTO);
+        return orderItems.map(orderItemMapper::toResponseDTO).map(this::enrichResponse);
     }
-    
+
     @Override
     public Page<OrderItemResponseDTO> getOrderItemsByStudentIdPaginated(String studentId, Pageable pageable) {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
-        
+
         Page<OrderItem> orderItems = orderItemRepository.findByOrderStudentStudentIdOrderByUpdatedAtDesc(studentId, pageable);
-        return orderItems.map(orderItemMapper::toResponseDTO);
+        return orderItems.map(orderItemMapper::toResponseDTO).map(this::enrichResponse);
     }
 
     @Override
@@ -192,13 +185,12 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
-        
         if (status == null) {
             throw new InvalidRequestException("Order status is required");
         }
-        
+
         Page<OrderItem> orderItems = orderItemRepository.findByOrderStudentStudentIdAndOrderStatusOrderByUpdatedAtDesc(studentId, status, pageable);
-        return orderItems.map(orderItemMapper::toResponseDTO);
+        return orderItems.map(orderItemMapper::toResponseDTO).map(this::enrichResponse);
     }
 
     @Override
@@ -207,18 +199,16 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (id == null || id <= 0) {
             throw new InvalidRequestException("Invalid order item ID");
         }
-        
         if (status == null) {
             throw new InvalidRequestException("Order status is required");
         }
-
         if (status == OrderStatus.CANCELLED) {
             throw new InvalidOrderStatusTransitionException("Use the order cancellation flow to set CANCELLED status");
         }
-        
+
         OrderItem orderItem = orderItemRepository.findById(id)
             .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
-        
+
         OrderStatus oldStatus = orderItem.getOrderStatus();
         Order order = orderItem.getOrder();
 
@@ -235,44 +225,41 @@ public class OrderItemServiceImpl implements OrderItemService {
             orderLifecycleService.applyTerminalStatus(order, OrderStatus.REJECTED);
             OrderItem updatedItem = orderItemRepository.findByIdWithStudentAndMerchDetails(id)
                     .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
-            return orderItemMapper.toResponseDTO(updatedItem);
+            return enrichResponse(orderItemMapper.toResponseDTO(updatedItem));
         }
 
         validateNonTerminalStatusTransition(oldStatus, status);
-
         if (oldStatus == status) {
-            return orderItemMapper.toResponseDTO(orderItem);
+            return enrichResponse(orderItemMapper.toResponseDTO(orderItem));
         }
-        
+
         try {
-            /* update order item status */
             orderItem.setOrderStatus(status);
             orderItem.setUpdatedAt(LocalDateTime.now());
-            
+
+            OrderStatus effectiveStatus = resolveEffectiveApprovedStatus(orderItem, status);
+            orderItem.setOrderStatus(effectiveStatus);
+
             OrderItem updatedOrderItem = orderItemRepository.save(orderItem);
             syncParentOrderStatus(order);
 
-            /* send notification email if order details are available */
-            OrderItem itemWithDetails = orderItemRepository.findByIdWithStudentAndMerchDetails(id)
-                .orElse(null);
+            activateMembershipWhenAccepted(updatedOrderItem, effectiveStatus);
+
+            OrderItem itemWithDetails = orderItemRepository.findByIdWithStudentAndMerchDetails(id).orElse(null);
             if (itemWithDetails != null) {
-                var notificationData = orderNotificationService.extractNotificationData(itemWithDetails, status);
+                var notificationData = orderNotificationService.extractNotificationData(itemWithDetails, effectiveStatus);
                 if (notificationData != null) {
                     orderNotificationService.sendOrderStatusEmail(notificationData);
                 }
             }
 
-            return orderItemMapper.toResponseDTO(updatedOrderItem);
+            return enrichResponse(orderItemMapper.toResponseDTO(updatedOrderItem));
         } catch (InvalidRequestException e) {
             throw e;
         } catch (Exception e) {
-            /* log error and rethrow to trigger transaction rollback */
-            System.err.println("Error updating order item status: " + e.getMessage());
-            e.printStackTrace();
             throw new InvalidRequestException("Failed to update order item status: " + e.getMessage());
         }
     }
-
 
     @Override
     @Transactional
@@ -280,19 +267,118 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (id == null || id <= 0) {
             throw new InvalidRequestException("Invalid order item ID");
         }
-        
         if (!orderItemRepository.existsById(id)) {
             throw new OrderItemNotFoundException("Order item not found");
         }
-        
+        ticketFreebieAssignmentRepository.deleteByOrderItemOrderItemId(id);
         orderItemRepository.deleteById(id);
+    }
+
+    private OrderItemResponseDTO enrichResponse(OrderItemResponseDTO response) {
+        response.setFreebieAssignments(ticketFreebieAssignmentService.getAssignmentsByOrderItemId(response.getOrderItemId()));
+        return response;
+    }
+
+    private List<TicketFreebieAssignmentRequestDTO> resolveAssignmentRequests(OrderItemRequestDTO request) {
+        if (request.getFreebieSelections() != null && !request.getFreebieSelections().isEmpty()) {
+            return request.getFreebieSelections().stream()
+                    .map(selection -> TicketFreebieAssignmentRequestDTO.builder()
+                            .ticketFreebieConfigId(selection.getTicketFreebieConfigId())
+                            .selectedSize(selection.getSelectedSize())
+                            .selectedColor(selection.getSelectedColor())
+                            .selectedDesign(selection.getSelectedDesign())
+                            .build())
+                    .toList();
+        }
+
+        if (request.getFreebieAssignments() != null && !request.getFreebieAssignments().isEmpty()) {
+            return request.getFreebieAssignments().stream()
+                    .map(assignment -> TicketFreebieAssignmentRequestDTO.builder()
+                            .ticketFreebieConfigId(assignment.getTicketFreebieConfigId())
+                            .selectedSize(assignment.getSelectedSize())
+                            .selectedColor(assignment.getSelectedColor())
+                            .selectedDesign(assignment.getSelectedDesign())
+                            .fulfillmentStatus(assignment.getFulfillmentStatus())
+                            .build())
+                    .toList();
+        }
+
+        return List.of();
+    }
+
+    private void validateTicketPurchaseEligibility(Order order, MerchVariantItem merchVariantItem) {
+        if (order == null || order.getStudent() == null || merchVariantItem == null
+                || merchVariantItem.getMerchVariant() == null || merchVariantItem.getMerchVariant().getMerch() == null) {
+            return;
+        }
+
+        if (merchVariantItem.getMerchVariant().getMerch().getMerchType() != MerchType.TICKET) {
+            return;
+        }
+
+        String studentId = order.getStudent().getStudentId();
+        Long merchId = merchVariantItem.getMerchVariant().getMerch().getMerchId();
+
+        // Student-facing ticket purchases should stop once the same ticket merch already exists
+        // in another active order. Cart ownership is enforced during add-to-cart and surfaced in
+        // merch responses so the frontend can disable purchase actions before checkout.
+        boolean alreadyInActiveOrder = orderItemRepository.existsByStudentIdAndMerchIdAndOrderStatusNotIn(
+                studentId,
+                merchId,
+                List.of(OrderStatus.CANCELLED, OrderStatus.REJECTED));
+        if (alreadyInActiveOrder) {
+            throw new InvalidRequestException(ITEM_ALREADY_IN_CART_OR_ORDER);
+        }
+    }
+
+    private void activateMembershipWhenAccepted(OrderItem orderItem, OrderStatus newStatus) {
+        if (orderItem == null || newStatus == null) {
+            return;
+        }
+        if (newStatus != OrderStatus.TO_BE_CLAIMED && newStatus != OrderStatus.CLAIMED) {
+            return;
+        }
+        if (orderItem.getMerchVariantItem() == null
+                || orderItem.getMerchVariantItem().getMerchVariant() == null
+                || orderItem.getMerchVariantItem().getMerchVariant().getMerch() == null
+                || orderItem.getOrder() == null
+                || orderItem.getOrder().getStudent() == null) {
+            return;
+        }
+
+        if (orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() != MerchType.MEMBERSHIP) {
+            return;
+        }
+
+        String studentId = orderItem.getOrder().getStudent().getStudentId();
+        if (studentId == null || studentId.isBlank()) {
+            return;
+        }
+
+        // Keep membership records aligned with accepted membership orders across all approval paths.
+        studentMembershipService.ensureMembershipForCurrentAcademicYear(studentId);
+    }
+
+    private OrderStatus resolveEffectiveApprovedStatus(OrderItem orderItem, OrderStatus requestedStatus) {
+        if (requestedStatus == OrderStatus.TO_BE_CLAIMED && isMembershipItem(orderItem)) {
+            return OrderStatus.CLAIMED;
+        }
+
+        return requestedStatus;
+    }
+
+    private boolean isMembershipItem(OrderItem orderItem) {
+        return orderItem != null
+                && orderItem.getMerchVariantItem() != null
+                && orderItem.getMerchVariantItem().getMerchVariant() != null
+                && orderItem.getMerchVariantItem().getMerchVariant().getMerch() != null
+                && orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP;
     }
 
     private String normalizeStudentScope(String studentId) {
         if (studentId == null) {
             return null;
         }
-
         String trimmedStudentId = studentId.trim();
         return trimmedStudentId.isEmpty() ? null : trimmedStudentId;
     }
@@ -311,11 +397,9 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (newStatus != OrderStatus.TO_BE_CLAIMED && newStatus != OrderStatus.CLAIMED) {
             throw new InvalidOrderStatusTransitionException("Only TO_BE_CLAIMED or CLAIMED are allowed through item updates");
         }
-
         if (oldStatus == OrderStatus.REJECTED || oldStatus == OrderStatus.CANCELLED) {
             throw new InvalidOrderStatusTransitionException("Terminal order items cannot be updated");
         }
-
         if (oldStatus == OrderStatus.PENDING && newStatus == OrderStatus.CLAIMED) {
             throw new InvalidOrderStatusTransitionException("Pending items must move to TO_BE_CLAIMED before CLAIMED");
         }
@@ -325,17 +409,13 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (order == null || order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
             return;
         }
-
         if (order.getOrderStatus() == OrderStatus.REJECTED || order.getOrderStatus() == OrderStatus.CANCELLED) {
             return;
         }
 
-        boolean allClaimed = order.getOrderItems().stream()
-                .allMatch(item -> item.getOrderStatus() == OrderStatus.CLAIMED);
-
+        boolean allClaimed = order.getOrderItems().stream().allMatch(item -> item.getOrderStatus() == OrderStatus.CLAIMED);
         boolean anyReadyOrClaimed = order.getOrderItems().stream()
-                .anyMatch(item -> item.getOrderStatus() == OrderStatus.TO_BE_CLAIMED
-                        || item.getOrderStatus() == OrderStatus.CLAIMED);
+                .anyMatch(item -> item.getOrderStatus() == OrderStatus.TO_BE_CLAIMED || item.getOrderStatus() == OrderStatus.CLAIMED);
 
         OrderStatus derivedStatus = allClaimed
                 ? OrderStatus.CLAIMED

--- a/src/main/java/org/csps/backend/service/impl/OrderItemServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/OrderItemServiceImpl.java
@@ -9,6 +9,7 @@ import org.csps.backend.domain.entities.MerchVariantItem;
 import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.entities.OrderItem;
 import org.csps.backend.domain.enums.OrderStatus;
+import org.csps.backend.exception.InvalidOrderStatusTransitionException;
 import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.exception.OrderItemNotFoundException;
 import org.csps.backend.exception.OrderNotFoundException;
@@ -17,6 +18,7 @@ import org.csps.backend.repository.MerchVariantItemRepository;
 import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.service.OrderItemService;
+import org.csps.backend.service.OrderLifecycleService;
 import org.csps.backend.service.OrderNotificationService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,6 +36,7 @@ public class OrderItemServiceImpl implements OrderItemService {
     private final MerchVariantItemRepository merchVariantItemRepository;
     private final OrderItemMapper orderItemMapper;
     private final OrderNotificationService orderNotificationService;
+    private final OrderLifecycleService orderLifecycleService;
     
     @Override
     @Transactional
@@ -62,19 +65,19 @@ public class OrderItemServiceImpl implements OrderItemService {
             throw new InvalidRequestException("Insufficient stock. Available: " + merchVariantItem.getStockQuantity() + 
                     ", Requested: " + orderItemRequestDTO.getQuantity());
         }
-        
-        /* validate price */
-        if (orderItemRequestDTO.getPriceAtPurchase() == null || orderItemRequestDTO.getPriceAtPurchase() < 0) {
-            throw new InvalidRequestException("Price at purchase must be non-negative");
+
+        Double priceSnapshot = merchVariantItem.getPrice();
+        if (priceSnapshot == null || priceSnapshot < 0) {
+            throw new InvalidRequestException("MerchVariantItem price must be configured before creating an order item");
         }
         
         try {
-            /* create order item with stock deduction to reserve inventory */
+            /* snapshot the current SKU price on the server to prevent client-side tampering */
             OrderItem orderItem = OrderItem.builder()
                 .order(order)
                 .merchVariantItem(merchVariantItem)
                 .quantity(orderItemRequestDTO.getQuantity())
-                .priceAtPurchase(orderItemRequestDTO.getPriceAtPurchase())
+                .priceAtPurchase(priceSnapshot)
                 .updatedAt(LocalDateTime.now())
                 .build();
             
@@ -110,13 +113,17 @@ public class OrderItemServiceImpl implements OrderItemService {
     }
     
     @Override
-    public OrderItemResponseDTO getOrderItemById(Long id) {
+    public OrderItemResponseDTO getOrderItemById(Long id, String studentId) {
         if (id == null || id <= 0) {
             throw new InvalidRequestException("Invalid order item ID");
         }
-        
-        OrderItem orderItem = orderItemRepository.findById(id)
-            .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
+
+        String studentScope = normalizeStudentScope(studentId);
+        OrderItem orderItem = studentScope == null
+            ? orderItemRepository.findByIdWithStudentAndMerchDetails(id)
+                .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"))
+            : orderItemRepository.findByOrderItemIdAndOrderStudentStudentId(id, studentScope)
+                .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
         
         return orderItemMapper.toResponseDTO(orderItem);
     }
@@ -127,44 +134,46 @@ public class OrderItemServiceImpl implements OrderItemService {
             throw new InvalidRequestException("Order status is required");
         }
         
-        if (studentId == null || studentId.isEmpty()) {
-            throw new InvalidRequestException("Student ID is required");
-        }
-        
-        Page<OrderItem> orderItems = orderItemRepository.findByOrderStatusAndOrderStudentStudentId(status, studentId, pageable);
+        String studentScope = normalizeStudentScope(studentId);
+        Page<OrderItem> orderItems = studentScope == null
+            ? orderItemRepository.findByOrderStatusOrderByUpdatedAtDesc(status, pageable)
+            : orderItemRepository.findByOrderStatusAndOrderStudentStudentId(status, studentScope, pageable);
+
         return orderItems.map(orderItemMapper::toResponseDTO);
 
     }
 
     @Override
-    public List<OrderItemResponseDTO> getOrderItemsByOrderId(Long orderId) {
+    public List<OrderItemResponseDTO> getOrderItemsByOrderId(Long orderId, String studentId) {
         if (orderId == null || orderId <= 0) {
             throw new InvalidRequestException("Invalid order ID");
         }
-        
-        // Verify order exists
-        if (!orderRepository.existsById(orderId)) {
-            throw new OrderNotFoundException("Order not found");
-        }
-        
-        List<OrderItem> orderItems = orderItemRepository.findByOrderOrderId(orderId);
+
+        String studentScope = normalizeStudentScope(studentId);
+        validateOrderAccess(orderId, studentScope);
+
+        List<OrderItem> orderItems = studentScope == null
+            ? orderItemRepository.findByOrderOrderId(orderId)
+            : orderItemRepository.findByOrderOrderIdAndOrderStudentStudentId(orderId, studentScope);
+
         return orderItems.stream()
             .map(orderItemMapper::toResponseDTO)
             .toList();
     }
     
     @Override
-    public Page<OrderItemResponseDTO> getOrderItemsByOrderIdPaginated(Long orderId, Pageable pageable) {
+    public Page<OrderItemResponseDTO> getOrderItemsByOrderIdPaginated(Long orderId, Pageable pageable, String studentId) {
         if (orderId == null || orderId <= 0) {
             throw new InvalidRequestException("Invalid order ID");
         }
-        
-        // Verify order exists
-        if (!orderRepository.existsById(orderId)) {
-            throw new OrderNotFoundException("Order not found");
-        }
-        
-        Page<OrderItem> orderItems = orderItemRepository.findByOrderOrderId(orderId, pageable);
+
+        String studentScope = normalizeStudentScope(studentId);
+        validateOrderAccess(orderId, studentScope);
+
+        Page<OrderItem> orderItems = studentScope == null
+            ? orderItemRepository.findByOrderOrderId(orderId, pageable)
+            : orderItemRepository.findByOrderOrderIdAndOrderStudentStudentId(orderId, studentScope, pageable);
+
         return orderItems.map(orderItemMapper::toResponseDTO);
     }
     
@@ -202,33 +211,46 @@ public class OrderItemServiceImpl implements OrderItemService {
         if (status == null) {
             throw new InvalidRequestException("Order status is required");
         }
+
+        if (status == OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Use the order cancellation flow to set CANCELLED status");
+        }
         
         OrderItem orderItem = orderItemRepository.findById(id)
             .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
         
         OrderStatus oldStatus = orderItem.getOrderStatus();
+        Order order = orderItem.getOrder();
+
+        if (order.getOrderStatus() == OrderStatus.REJECTED || order.getOrderStatus() == OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Terminal orders cannot be updated through item status changes");
+        }
+
+        if (status == OrderStatus.REJECTED) {
+            List<OrderItem> siblingItems = order.getOrderItems();
+            if (siblingItems != null && siblingItems.size() > 1) {
+                throw new InvalidOrderStatusTransitionException("Use the order rejection flow for multi-item orders");
+            }
+
+            orderLifecycleService.applyTerminalStatus(order, OrderStatus.REJECTED);
+            OrderItem updatedItem = orderItemRepository.findByIdWithStudentAndMerchDetails(id)
+                    .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
+            return orderItemMapper.toResponseDTO(updatedItem);
+        }
+
+        validateNonTerminalStatusTransition(oldStatus, status);
+
+        if (oldStatus == status) {
+            return orderItemMapper.toResponseDTO(orderItem);
+        }
         
         try {
-            /* restore stock only when transitioning TO REJECTED status (prevent duplicate restorations) */
-            if (status == OrderStatus.REJECTED && oldStatus != OrderStatus.REJECTED) {
-                /* acquire pessimistic lock on merch variant item to ensure thread-safe stock restoration */
-                MerchVariantItem merchVariantItem = merchVariantItemRepository.findByIdWithLock(orderItem.getMerchVariantItem().getMerchVariantItemId())
-                    .orElseThrow(() -> new InvalidRequestException("MerchVariantItem not found during stock restoration"));
-                
-                /* restore stock when order is rejected */
-                int restoredStockQuantity = merchVariantItem.getStockQuantity() + orderItem.getQuantity();
-                merchVariantItem.setStockQuantity(restoredStockQuantity);
-                merchVariantItemRepository.save(merchVariantItem);
-                
-                System.out.println("Stock restored due to order rejection. Quantity: " + orderItem.getQuantity() + 
-                    " | Previous status: " + oldStatus + " -> New status: " + status);
-            }
-            
             /* update order item status */
             orderItem.setOrderStatus(status);
             orderItem.setUpdatedAt(LocalDateTime.now());
             
             OrderItem updatedOrderItem = orderItemRepository.save(orderItem);
+            syncParentOrderStatus(order);
 
             /* send notification email if order details are available */
             OrderItem itemWithDetails = orderItemRepository.findByIdWithStudentAndMerchDetails(id)
@@ -264,5 +286,65 @@ public class OrderItemServiceImpl implements OrderItemService {
         }
         
         orderItemRepository.deleteById(id);
+    }
+
+    private String normalizeStudentScope(String studentId) {
+        if (studentId == null) {
+            return null;
+        }
+
+        String trimmedStudentId = studentId.trim();
+        return trimmedStudentId.isEmpty() ? null : trimmedStudentId;
+    }
+
+    private void validateOrderAccess(Long orderId, String studentId) {
+        boolean orderAccessible = studentId == null
+            ? orderRepository.existsById(orderId)
+            : orderRepository.findByOrderIdAndStudentStudentId(orderId, studentId).isPresent();
+
+        if (!orderAccessible) {
+            throw new OrderNotFoundException("Order not found");
+        }
+    }
+
+    private void validateNonTerminalStatusTransition(OrderStatus oldStatus, OrderStatus newStatus) {
+        if (newStatus != OrderStatus.TO_BE_CLAIMED && newStatus != OrderStatus.CLAIMED) {
+            throw new InvalidOrderStatusTransitionException("Only TO_BE_CLAIMED or CLAIMED are allowed through item updates");
+        }
+
+        if (oldStatus == OrderStatus.REJECTED || oldStatus == OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Terminal order items cannot be updated");
+        }
+
+        if (oldStatus == OrderStatus.PENDING && newStatus == OrderStatus.CLAIMED) {
+            throw new InvalidOrderStatusTransitionException("Pending items must move to TO_BE_CLAIMED before CLAIMED");
+        }
+    }
+
+    private void syncParentOrderStatus(Order order) {
+        if (order == null || order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            return;
+        }
+
+        if (order.getOrderStatus() == OrderStatus.REJECTED || order.getOrderStatus() == OrderStatus.CANCELLED) {
+            return;
+        }
+
+        boolean allClaimed = order.getOrderItems().stream()
+                .allMatch(item -> item.getOrderStatus() == OrderStatus.CLAIMED);
+
+        boolean anyReadyOrClaimed = order.getOrderItems().stream()
+                .anyMatch(item -> item.getOrderStatus() == OrderStatus.TO_BE_CLAIMED
+                        || item.getOrderStatus() == OrderStatus.CLAIMED);
+
+        OrderStatus derivedStatus = allClaimed
+                ? OrderStatus.CLAIMED
+                : anyReadyOrClaimed ? OrderStatus.TO_BE_CLAIMED : OrderStatus.PENDING;
+
+        if (order.getOrderStatus() != derivedStatus) {
+            order.setOrderStatus(derivedStatus);
+            order.setUpdatedAt(LocalDateTime.now());
+            orderRepository.save(order);
+        }
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/OrderLifecycleServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/OrderLifecycleServiceImpl.java
@@ -1,0 +1,73 @@
+package org.csps.backend.service.impl;
+
+import java.time.LocalDateTime;
+
+import org.csps.backend.domain.entities.MerchVariantItem;
+import org.csps.backend.domain.entities.Order;
+import org.csps.backend.domain.entities.OrderItem;
+import org.csps.backend.domain.enums.OrderStatus;
+import org.csps.backend.exception.InvalidOrderStatusTransitionException;
+import org.csps.backend.exception.InvalidRequestException;
+import org.csps.backend.repository.MerchVariantItemRepository;
+import org.csps.backend.repository.OrderItemRepository;
+import org.csps.backend.repository.OrderRepository;
+import org.csps.backend.service.OrderLifecycleService;
+import org.springframework.stereotype.Service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OrderLifecycleServiceImpl implements OrderLifecycleService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final MerchVariantItemRepository merchVariantItemRepository;
+
+    @Override
+    @Transactional
+    public Order applyTerminalStatus(Order order, OrderStatus targetStatus) {
+        if (order == null || order.getOrderId() == null) {
+            throw new InvalidRequestException("Order is required");
+        }
+
+        if (targetStatus != OrderStatus.REJECTED && targetStatus != OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Unsupported terminal order status: " + targetStatus);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if (order.getOrderItems() != null) {
+            for (OrderItem item : order.getOrderItems()) {
+                if (item == null) {
+                    continue;
+                }
+
+                if (shouldRestoreStock(item.getOrderStatus())) {
+                    MerchVariantItem lockedItem = merchVariantItemRepository.findByIdWithLock(
+                            item.getMerchVariantItem().getMerchVariantItemId())
+                            .orElseThrow(() -> new InvalidRequestException(
+                                    "MerchVariantItem not found during stock restoration"));
+
+                    lockedItem.setStockQuantity(lockedItem.getStockQuantity() + item.getQuantity());
+                    merchVariantItemRepository.save(lockedItem);
+                }
+
+                if (item.getOrderStatus() != targetStatus) {
+                    item.setOrderStatus(targetStatus);
+                    item.setUpdatedAt(now);
+                    orderItemRepository.save(item);
+                }
+            }
+        }
+
+        order.setOrderStatus(targetStatus);
+        order.setUpdatedAt(now);
+        return orderRepository.save(order);
+    }
+
+    private boolean shouldRestoreStock(OrderStatus currentStatus) {
+        return currentStatus != OrderStatus.REJECTED && currentStatus != OrderStatus.CANCELLED;
+    }
+}

--- a/src/main/java/org/csps/backend/service/impl/OrderServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/OrderServiceImpl.java
@@ -2,6 +2,7 @@ package org.csps.backend.service.impl;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Locale;
 
 import org.csps.backend.domain.dtos.request.OrderItemRequestDTO;
 import org.csps.backend.domain.dtos.request.OrderPostRequestDTO;
@@ -12,15 +13,18 @@ import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.entities.Student;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.exception.CartItemNotFoundException;
+import org.csps.backend.exception.InvalidOrderStatusTransitionException;
 import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.exception.OrderNotFoundException;
 import org.csps.backend.exception.StudentNotFoundException;
 import org.csps.backend.mapper.OrderMapper;
+import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.repository.StudentRepository;
 import org.csps.backend.repository.specification.OrderSpecification;
 import org.csps.backend.service.CartItemService;
 import org.csps.backend.service.MerchService;
+import org.csps.backend.service.OrderLifecycleService;
 import org.csps.backend.service.OrderItemService;
 import org.csps.backend.service.OrderService;
 import org.springframework.data.domain.Page;
@@ -36,11 +40,13 @@ import lombok.RequiredArgsConstructor;
 public class OrderServiceImpl implements OrderService {
 
     private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
     private final OrderMapper orderMapper;
     private final StudentRepository studentRepository;
 
 
     private final OrderItemService orderItemService;
+    private final OrderLifecycleService orderLifecycleService;
     private final CartItemService cartItemService;
 
     private final MerchService merchService;
@@ -119,13 +125,16 @@ public class OrderServiceImpl implements OrderService {
     }
 
     @Override
-    public OrderResponseDTO getOrderById(Long orderId) {
+    public OrderResponseDTO getOrderById(Long orderId, String studentId) {
         if (orderId == null || orderId <= 0) {
             throw new InvalidRequestException("Invalid order ID");
         }
-        
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        Order order = studentId == null || studentId.isBlank()
+                ? orderRepository.findById(orderId)
+                    .orElseThrow(() -> new OrderNotFoundException("Order not found"))
+                : orderRepository.findByOrderIdAndStudentStudentId(orderId, studentId)
+                    .orElseThrow(() -> new OrderNotFoundException("Order not found"));
         
         return orderMapper.toResponseDTO(order);
     }
@@ -177,20 +186,98 @@ public class OrderServiceImpl implements OrderService {
         
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("Order not found"));
-        
-        // Delete cascades to order items due to orphanRemoval = true
+
+        if (order.getOrderItems() != null && !order.getOrderItems().isEmpty()) {
+            orderItemRepository.deleteAllInBatch(order.getOrderItems());
+        }
+
         orderRepository.delete(order);
     }
 
     @Override
-    public Page<OrderResponseDTO> searchOrders(OrderSearchDTO searchDTO, Pageable pageable) {
-        if (searchDTO == null) {
-            searchDTO = new OrderSearchDTO();
-        }
-        
-        Specification<Order> spec = OrderSpecification.withFilters(searchDTO);
+    public Page<OrderResponseDTO> searchOrders(OrderSearchDTO searchDTO, Pageable pageable, String studentId) {
+        OrderSearchDTO normalizedSearch = normalizeAndValidateSearch(searchDTO);
+        Specification<Order> spec = OrderSpecification.withFilters(normalizedSearch, studentId);
         Page<Order> orders = orderRepository.findAll(spec, pageable);
         return orders.map(orderMapper::toResponseDTO);
+    }
+
+    @Override
+    @Transactional
+    public OrderResponseDTO cancelOrder(String studentId, Long orderId) {
+        if (studentId == null || studentId.isBlank()) {
+            throw new InvalidRequestException("Student ID is required");
+        }
+
+        if (orderId == null || orderId <= 0) {
+            throw new InvalidRequestException("Invalid order ID");
+        }
+
+        Order order = orderRepository.findByOrderIdAndStudentStudentId(orderId, studentId)
+                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        if (order.getOrderStatus() == OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Cancelled orders cannot be cancelled again");
+        }
+
+        if (order.getOrderStatus() != OrderStatus.PENDING) {
+            throw new InvalidOrderStatusTransitionException("Only pending orders can be cancelled");
+        }
+
+        if (order.getOrderItems() != null && order.getOrderItems().stream()
+                .anyMatch(item -> item.getOrderStatus() != OrderStatus.PENDING)) {
+            throw new InvalidOrderStatusTransitionException("Only orders with pending items can be cancelled");
+        }
+
+        Order cancelledOrder = orderLifecycleService.applyTerminalStatus(order, OrderStatus.CANCELLED);
+        return orderMapper.toResponseDTO(cancelledOrder);
+    }
+
+    private OrderSearchDTO normalizeAndValidateSearch(OrderSearchDTO searchDTO) {
+        OrderSearchDTO normalizedSearch = searchDTO == null ? new OrderSearchDTO() : searchDTO;
+
+        normalizedSearch.setStudentName(normalizeWhitespace(normalizedSearch.getStudentName()));
+        normalizedSearch.setStudentId(trimToNull(normalizedSearch.getStudentId()));
+        normalizedSearch.setStatus(normalizeStatus(normalizedSearch.getStatus()));
+
+        if (normalizedSearch.getStartDate() != null
+                && normalizedSearch.getEndDate() != null
+                && normalizedSearch.getEndDate().isBefore(normalizedSearch.getStartDate())) {
+            throw new InvalidRequestException("End date must be greater than or equal to start date");
+        }
+
+        if (normalizedSearch.getStatus() != null) {
+            try {
+                OrderStatus.valueOf(normalizedSearch.getStatus());
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidRequestException("Invalid order status: " + normalizedSearch.getStatus());
+            }
+        }
+
+        if (normalizedSearch.getYear() != null
+                && (normalizedSearch.getYear() < 1000 || normalizedSearch.getYear() > 9999)) {
+            throw new InvalidRequestException("Year filter must be a four-digit year");
+        }
+
+        return normalizedSearch;
+    }
+
+    private String normalizeStatus(String status) {
+        String trimmedStatus = trimToNull(status);
+        return trimmedStatus == null ? null : trimmedStatus.toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizeWhitespace(String value) {
+        return value == null ? null : value.trim().replaceAll("\\s+", " ");
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }
 

--- a/src/main/java/org/csps/backend/service/impl/OrderServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/OrderServiceImpl.java
@@ -3,10 +3,14 @@ package org.csps.backend.service.impl;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.csps.backend.domain.dtos.request.OrderItemRequestDTO;
 import org.csps.backend.domain.dtos.request.OrderPostRequestDTO;
 import org.csps.backend.domain.dtos.request.OrderSearchDTO;
+import org.csps.backend.domain.dtos.request.TicketFreebieSelectionRequestDTO;
+import org.csps.backend.domain.dtos.response.CartItemFreebieSelectionItemResponseDTO;
+import org.csps.backend.domain.dtos.response.CartItemResponseDTO;
 import org.csps.backend.domain.dtos.response.OrderItemResponseDTO;
 import org.csps.backend.domain.dtos.response.OrderResponseDTO;
 import org.csps.backend.domain.entities.Order;
@@ -21,12 +25,13 @@ import org.csps.backend.mapper.OrderMapper;
 import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.repository.StudentRepository;
+import org.csps.backend.repository.TicketFreebieAssignmentRepository;
 import org.csps.backend.repository.specification.OrderSpecification;
 import org.csps.backend.service.CartItemService;
-import org.csps.backend.service.MerchService;
-import org.csps.backend.service.OrderLifecycleService;
 import org.csps.backend.service.OrderItemService;
+import org.csps.backend.service.OrderLifecycleService;
 import org.csps.backend.service.OrderService;
+import org.csps.backend.service.TicketFreebieAssignmentService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
@@ -43,14 +48,11 @@ public class OrderServiceImpl implements OrderService {
     private final OrderItemRepository orderItemRepository;
     private final OrderMapper orderMapper;
     private final StudentRepository studentRepository;
-
-
     private final OrderItemService orderItemService;
     private final OrderLifecycleService orderLifecycleService;
     private final CartItemService cartItemService;
-
-    private final MerchService merchService;
-
+    private final TicketFreebieAssignmentService ticketFreebieAssignmentService;
+    private final TicketFreebieAssignmentRepository ticketFreebieAssignmentRepository;
 
     @Override
     @Transactional
@@ -58,70 +60,63 @@ public class OrderServiceImpl implements OrderService {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
-        
         if (orderRequests == null || orderRequests.getOrderItems() == null || orderRequests.getOrderItems().isEmpty()) {
             throw new InvalidRequestException("At least one order request is required");
         }
-        
-        // Validate student exists
+
         Student student = studentRepository.findByStudentId(studentId)
                 .orElseThrow(() -> new StudentNotFoundException("Student not found"));
-        
-        // Create order
+
         Order order = Order.builder()
                 .student(student)
                 .orderDate(LocalDateTime.now())
-                .totalPrice(0.0) // Will be updated after adding order items
+                .totalPrice(0.0)
                 .updatedAt(LocalDateTime.now())
-                .orderStatus(OrderStatus.PENDING) // Default status for new orders
+                .orderStatus(OrderStatus.PENDING)
                 .quantity(0)
                 .build();
 
-        // Save order first to get the generated orderId
         Order savedOrder = orderRepository.save(order);
-
-        List<OrderItemRequestDTO> orderItemRequests = orderRequests.getOrderItems();
-        
-        // Now set the orderId on all item requests
-        orderItemRequests.forEach(req -> {
-            req.setOrderId(savedOrder.getOrderId());
-        });
+        List<OrderItemRequestDTO> orderItemRequests = prepareOrderItemsFromCart(
+                studentId,
+                savedOrder.getOrderId(),
+                orderRequests.getOrderItems());
 
         double totalPrice = 0.0;
+        int totalQuantity = 0;
         for (OrderItemRequestDTO itemRequest : orderItemRequests) {
             OrderItemResponseDTO orderItemResponse = orderItemService.createOrderItem(itemRequest);
             totalPrice += orderItemResponse.getTotalPrice();
-            
-            // Remove the item from cart after successful order item creation
+            totalQuantity += itemRequest.getQuantity() == null ? 0 : itemRequest.getQuantity();
+
             try {
                 cartItemService.removeCartItem(studentId, itemRequest.getMerchVariantItemId());
-            } catch (CartItemNotFoundException e) {
-                // Item not in cart is OK - might have been removed already
-            } catch (Exception e) {
-                // Log other failures but don't fail the order
-                System.err.println("Error: Failed to remove item from cart after ordering: " + e.getMessage());
-                e.printStackTrace();
+            } catch (CartItemNotFoundException ignored) {
             }
         }
 
         savedOrder.setTotalPrice(totalPrice);
+        savedOrder.setQuantity(totalQuantity);
         orderRepository.save(savedOrder);
-        
-        return orderMapper.toResponseDTO(savedOrder);
+
+        Order reloadedOrder = orderRepository.findByOrderIdAndStudentStudentId(savedOrder.getOrderId(), studentId)
+                .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+        return enrichOrderResponse(orderMapper.toResponseDTO(reloadedOrder));
     }
 
     @Override
     public List<OrderResponseDTO> getAllOrders() {
-        return orderRepository.findAll()
-                .stream()
+        return orderRepository.findAll().stream()
                 .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse)
                 .toList();
     }
 
     @Override
     public Page<OrderResponseDTO> getAllOrdersPaginated(Pageable pageable) {
-        Page<Order> orders = orderRepository.findAll(pageable);
-        return orders.map(orderMapper::toResponseDTO);
+        return orderRepository.findAll(pageable)
+                .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse);
     }
 
     @Override
@@ -131,18 +126,18 @@ public class OrderServiceImpl implements OrderService {
         }
 
         Order order = studentId == null || studentId.isBlank()
-                ? orderRepository.findById(orderId)
-                    .orElseThrow(() -> new OrderNotFoundException("Order not found"))
+                ? orderRepository.findByOrderId(orderId).orElseThrow(() -> new OrderNotFoundException("Order not found"))
                 : orderRepository.findByOrderIdAndStudentStudentId(orderId, studentId)
-                    .orElseThrow(() -> new OrderNotFoundException("Order not found"));
-        
-        return orderMapper.toResponseDTO(order);
+                        .orElseThrow(() -> new OrderNotFoundException("Order not found"));
+
+        return enrichOrderResponse(orderMapper.toResponseDTO(order));
     }
 
     @Override
     public Page<OrderResponseDTO> getAllOrdersPaginatedSortByDate(Pageable pageable) {
-        Page<Order> orders = orderRepository.findAllByOrderByOrderDateDesc(pageable);
-        return orders.map(orderMapper::toResponseDTO);
+        return orderRepository.findAllByOrderByOrderDateDesc(pageable)
+                .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse);
     }
 
     @Override
@@ -150,15 +145,13 @@ public class OrderServiceImpl implements OrderService {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
-        
-        // Verify student exists
         if (!studentRepository.existsById(studentId)) {
             throw new StudentNotFoundException("Student not found");
         }
-        
-        return orderRepository.findByStudentId(studentId)
-                .stream()
+
+        return orderRepository.findByStudentId(studentId).stream()
                 .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse)
                 .toList();
     }
 
@@ -167,14 +160,13 @@ public class OrderServiceImpl implements OrderService {
         if (studentId == null || studentId.isEmpty()) {
             throw new InvalidRequestException("Student ID is required");
         }
-        
-        // Verify student exists
         if (!studentRepository.existsById(studentId)) {
             throw new StudentNotFoundException("Student not found");
         }
-        
-        Page<Order> orders = orderRepository.findByStudentId(studentId, pageable);
-        return orders.map(orderMapper::toResponseDTO);
+
+        return orderRepository.findByStudentId(studentId, pageable)
+                .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse);
     }
 
     @Override
@@ -183,11 +175,18 @@ public class OrderServiceImpl implements OrderService {
         if (orderId == null || orderId <= 0) {
             throw new InvalidRequestException("Invalid order ID");
         }
-        
+
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException("Order not found"));
 
         if (order.getOrderItems() != null && !order.getOrderItems().isEmpty()) {
+            List<Long> orderItemIds = order.getOrderItems().stream()
+                    .map(item -> item.getOrderItemId())
+                    .filter(id -> id != null)
+                    .toList();
+            if (!orderItemIds.isEmpty()) {
+                ticketFreebieAssignmentRepository.deleteByOrderItemOrderItemIdIn(orderItemIds);
+            }
             orderItemRepository.deleteAllInBatch(order.getOrderItems());
         }
 
@@ -198,8 +197,9 @@ public class OrderServiceImpl implements OrderService {
     public Page<OrderResponseDTO> searchOrders(OrderSearchDTO searchDTO, Pageable pageable, String studentId) {
         OrderSearchDTO normalizedSearch = normalizeAndValidateSearch(searchDTO);
         Specification<Order> spec = OrderSpecification.withFilters(normalizedSearch, studentId);
-        Page<Order> orders = orderRepository.findAll(spec, pageable);
-        return orders.map(orderMapper::toResponseDTO);
+        return orderRepository.findAll(spec, pageable)
+                .map(orderMapper::toResponseDTO)
+                .map(this::enrichOrderResponse);
     }
 
     @Override
@@ -208,7 +208,6 @@ public class OrderServiceImpl implements OrderService {
         if (studentId == null || studentId.isBlank()) {
             throw new InvalidRequestException("Student ID is required");
         }
-
         if (orderId == null || orderId <= 0) {
             throw new InvalidRequestException("Invalid order ID");
         }
@@ -219,23 +218,70 @@ public class OrderServiceImpl implements OrderService {
         if (order.getOrderStatus() == OrderStatus.CANCELLED) {
             throw new InvalidOrderStatusTransitionException("Cancelled orders cannot be cancelled again");
         }
-
         if (order.getOrderStatus() != OrderStatus.PENDING) {
             throw new InvalidOrderStatusTransitionException("Only pending orders can be cancelled");
         }
-
         if (order.getOrderItems() != null && order.getOrderItems().stream()
                 .anyMatch(item -> item.getOrderStatus() != OrderStatus.PENDING)) {
             throw new InvalidOrderStatusTransitionException("Only orders with pending items can be cancelled");
         }
 
         Order cancelledOrder = orderLifecycleService.applyTerminalStatus(order, OrderStatus.CANCELLED);
-        return orderMapper.toResponseDTO(cancelledOrder);
+        return enrichOrderResponse(orderMapper.toResponseDTO(cancelledOrder));
+    }
+
+    private List<OrderItemRequestDTO> prepareOrderItemsFromCart(
+            String studentId,
+            Long orderId,
+            List<OrderItemRequestDTO> rawRequests) {
+        for (OrderItemRequestDTO rawRequest : rawRequests) {
+            rawRequest.setOrderId(orderId);
+
+            if (rawRequest.getFreebieSelections() != null && !rawRequest.getFreebieSelections().isEmpty()) {
+                continue;
+            }
+
+            try {
+                CartItemResponseDTO cartItem = cartItemService.getCartItemByMerchVariantItemId(studentId, rawRequest.getMerchVariantItemId());
+                rawRequest.setQuantity(cartItem.getQuantity());
+                rawRequest.setFreebieSelections(cartItem.getFreebieSelections() == null ? List.of() : cartItem.getFreebieSelections().stream()
+                        .map(this::toSelectionRequest)
+                        .toList());
+            } catch (CartItemNotFoundException ignored) {
+            }
+        }
+
+        return rawRequests;
+    }
+
+    private OrderResponseDTO enrichOrderResponse(OrderResponseDTO response) {
+        if (response == null || response.getOrderItems() == null || response.getOrderItems().isEmpty()) {
+            return response;
+        }
+
+        List<Long> orderItemIds = response.getOrderItems().stream()
+                .map(OrderItemResponseDTO::getOrderItemId)
+                .filter(id -> id != null)
+                .toList();
+        Map<Long, List<org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO>> assignments =
+                ticketFreebieAssignmentService.getAssignmentsByOrderItemIds(orderItemIds);
+
+        response.getOrderItems().forEach(orderItem ->
+                orderItem.setFreebieAssignments(assignments.get(orderItem.getOrderItemId())));
+        return response;
+    }
+
+    private TicketFreebieSelectionRequestDTO toSelectionRequest(CartItemFreebieSelectionItemResponseDTO selection) {
+        return TicketFreebieSelectionRequestDTO.builder()
+                .ticketFreebieConfigId(selection.getTicketFreebieConfigId())
+                .selectedSize(selection.getSelectedSize())
+                .selectedColor(selection.getSelectedColor())
+                .selectedDesign(selection.getSelectedDesign())
+                .build();
     }
 
     private OrderSearchDTO normalizeAndValidateSearch(OrderSearchDTO searchDTO) {
         OrderSearchDTO normalizedSearch = searchDTO == null ? new OrderSearchDTO() : searchDTO;
-
         normalizedSearch.setStudentName(normalizeWhitespace(normalizedSearch.getStudentName()));
         normalizedSearch.setStudentId(trimToNull(normalizedSearch.getStudentId()));
         normalizedSearch.setStatus(normalizeStatus(normalizedSearch.getStatus()));
@@ -245,7 +291,6 @@ public class OrderServiceImpl implements OrderService {
                 && normalizedSearch.getEndDate().isBefore(normalizedSearch.getStartDate())) {
             throw new InvalidRequestException("End date must be greater than or equal to start date");
         }
-
         if (normalizedSearch.getStatus() != null) {
             try {
                 OrderStatus.valueOf(normalizedSearch.getStatus());
@@ -253,7 +298,6 @@ public class OrderServiceImpl implements OrderService {
                 throw new InvalidRequestException("Invalid order status: " + normalizedSearch.getStatus());
             }
         }
-
         if (normalizedSearch.getYear() != null
                 && (normalizedSearch.getYear() < 1000 || normalizedSearch.getYear() > 9999)) {
             throw new InvalidRequestException("Year filter must be a four-digit year");
@@ -275,9 +319,7 @@ public class OrderServiceImpl implements OrderService {
         if (value == null) {
             return null;
         }
-
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
     }
 }
-

--- a/src/main/java/org/csps/backend/service/impl/RecoveryTokenServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/RecoveryTokenServiceImpl.java
@@ -10,10 +10,12 @@ import org.csps.backend.domain.entities.UserProfile;
 import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.exception.ResourceNotFoundException;
 import org.csps.backend.repository.RecoveryTokenRepository;
+import org.csps.backend.repository.UserAccountRepository;
 import org.csps.backend.repository.UserProfileRepository;
 import org.csps.backend.service.EmailService;
 import org.csps.backend.service.RecoveryTokenService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import jakarta.transaction.Transactional;
@@ -24,51 +26,49 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class RecoveryTokenServiceImpl implements RecoveryTokenService {
-    
+
     private final RecoveryTokenRepository recoveryTokenRepository;
+    private final UserAccountRepository userAccountRepository;
     private final UserProfileRepository userProfileRepository;
-    private final EmailService  emailService;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
 
     @Value("${FRONTEND_URL}")
     private String frontendUrl;
-    
+
     @Value("${csps.recovery.token.expiration.minutes:60}")
     private long tokenExpirationMinutes;
-    
+
     @Override
     @Transactional
     public RecoveryToken generateRecoveryToken(PasswordRecoveryRequestDTO requestDTO) {
-
         UserProfile userProfile = userProfileRepository.findByEmail(requestDTO.getEmail())
                 .orElseThrow(() -> new ResourceNotFoundException("user not found with email: " + requestDTO.getEmail()));
-        
-        
+
         UserAccount userAccount = userProfile.getUserAccounts().stream()
                 .filter(UserAccount::getIsVerified)
                 .findFirst()
                 .orElseThrow(() -> new ResourceNotFoundException("no verified user account found for email: " + requestDTO.getEmail()));
-        
-        if (userAccount == null || userAccount.getUserAccountId() == null) {
+
+        if (userAccount.getUserAccountId() == null) {
             throw new InvalidRequestException("user account is required");
         }
 
-        if (!userAccount.getIsVerified())
+        if (!userAccount.getIsVerified()) {
             throw new InvalidRequestException("user account is not verified");
-            
-        
-        // revoke previous valid tokens
+        }
+
         revokeAllTokensForUser(userAccount);
-        
-        // generate new token
+
         String token = UUID.randomUUID().toString();
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiresAt = now.plusMinutes(tokenExpirationMinutes);
-        
+
         String recoveryLink = buildRecoveryLink(token);
         String userName = userProfile.getFirstName() != null ? userProfile.getFirstName() : userAccount.getUsername();
-        
+
         emailService.sendPasswordRecoveryEmail(requestDTO.getEmail(), userName, recoveryLink);
-        
+
         RecoveryToken recoveryToken = RecoveryToken.builder()
                 .userAccount(userAccount)
                 .token(token)
@@ -76,30 +76,29 @@ public class RecoveryTokenServiceImpl implements RecoveryTokenService {
                 .expiresAt(expiresAt)
                 .isUsed(false)
                 .build();
-        
+
         RecoveryToken savedToken = recoveryTokenRepository.save(recoveryToken);
         log.info("recovery token generated for user: {}", userAccount.getUserAccountId());
         return savedToken;
     }
-    
+
     @Override
     public RecoveryToken validateRecoveryToken(String token) {
         if (token == null || token.isEmpty()) {
             throw new InvalidRequestException("recovery token is required");
         }
-        
+
         RecoveryToken recoveryToken = recoveryTokenRepository.findByToken(token)
                 .orElseThrow(() -> new ResourceNotFoundException("recovery token not found"));
-        
-        // check if token is valid
+
         if (!recoveryToken.isValid()) {
             log.warn("recovery token is invalid or expired: {}", token);
             throw new InvalidRequestException("recovery token is invalid or expired");
         }
-        
+
         return recoveryToken;
     }
-    
+
     @Override
     @Transactional
     public void markTokenAsUsed(String token) {
@@ -107,25 +106,37 @@ public class RecoveryTokenServiceImpl implements RecoveryTokenService {
         recoveryTokenRepository.markAsUsed(recoveryToken.getRecoveryTokenId());
         log.info("recovery token marked as used: {}", token);
     }
-    
+
+    @Override
+    @Transactional
+    public void resetPassword(String token, String newPassword) {
+        RecoveryToken recoveryToken = validateRecoveryToken(token);
+        UserAccount userAccount = recoveryToken.getUserAccount();
+
+        userAccount.setPassword(passwordEncoder.encode(newPassword));
+        userAccountRepository.save(userAccount);
+        recoveryTokenRepository.markAsUsed(recoveryToken.getRecoveryTokenId());
+
+        log.info("password reset successfully for user: {}", userAccount.getUserAccountId());
+    }
+
     @Override
     public RecoveryToken getValidTokenForUser(UserAccount userAccount) {
         if (userAccount == null || userAccount.getUserAccountId() == null) {
             throw new InvalidRequestException("user account is required");
         }
-        
+
         return recoveryTokenRepository.findValidTokenByUserAccountId(userAccount.getUserAccountId())
                 .orElseThrow(() -> new ResourceNotFoundException("no valid recovery token found for user"));
     }
-    
+
     @Override
     @Transactional
     public void revokeAllTokensForUser(UserAccount userAccount) {
         if (userAccount == null || userAccount.getUserAccountId() == null) {
             return;
         }
-        
-        // mark all valid tokens as used
+
         recoveryTokenRepository.findValidTokenByUserAccountId(userAccount.getUserAccountId())
                 .ifPresentOrElse(
                     token -> {
@@ -135,19 +146,15 @@ public class RecoveryTokenServiceImpl implements RecoveryTokenService {
                     () -> log.debug("no valid tokens to revoke for user: {}", userAccount.getUserAccountId())
                 );
     }
-    
+
     @Override
     @Transactional
     public void cleanupExpiredTokens() {
         log.info("cleaning up expired recovery tokens");
         recoveryTokenRepository.deleteExpiredTokens();
     }
-       /**
-     * Build recovery link for email
-     */
+
     private String buildRecoveryLink(String token) {
-        /* This should match your frontend URL */
-        String baseUrl = frontendUrl; // Adjust to your frontend URL
-        return baseUrl + "/reset-password?token=" + token;
+        return frontendUrl + "/reset-password?token=" + token;
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/RefreshTokenServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/RefreshTokenServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.csps.backend.domain.dtos.request.SignInCredentialRequestDTO;
 import org.csps.backend.domain.entities.RefreshToken;
 import org.csps.backend.domain.entities.UserAccount;
 import org.csps.backend.repository.RefreshTokenRepository;
@@ -20,11 +19,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Builder
 @RequiredArgsConstructor
-public class RefreshTokenServiceImpl implements RefreshTokenService{
+public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final UserAccountService userAccountService;
-
     private final RefreshTokenRepository refreshTokenRepository;
-
     private final JwtService jwtService;
 
     @Override
@@ -32,26 +29,20 @@ public class RefreshTokenServiceImpl implements RefreshTokenService{
         UserAccount user = userAccountService.findById(userId)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
-        // Check if the user already has a refresh token
-        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserAccount(user);
+        RefreshToken refreshToken = refreshTokenRepository.findByUserAccount(user)
+                .orElseGet(() -> {
+                    RefreshToken newToken = new RefreshToken();
+                    newToken.setUserAccount(user);
+                    return newToken;
+                });
 
-        RefreshToken refreshToken;
-        if (existingToken.isPresent()) {
-            refreshToken = existingToken.get();
-            refreshToken.setRefreshToken(UUID.randomUUID().toString());
-            refreshToken.setExpiryDate();
-        } else {
-            refreshToken = new RefreshToken();
-            refreshToken.setUserAccount(user);
-            refreshToken.setRefreshToken(UUID.randomUUID().toString());
-            refreshToken.setExpiryDate();
-        }
-
+        refreshToken.setRefreshToken(UUID.randomUUID().toString());
+        refreshToken.refreshExpiryDate();
         return refreshTokenRepository.save(refreshToken);
     }
 
     @Override
-    public Optional<RefreshToken> findByRefreshToken (String token) {
+    public Optional<RefreshToken> findByRefreshToken(String token) {
         return refreshTokenRepository.findByRefreshToken(token);
     }
 
@@ -61,9 +52,9 @@ public class RefreshTokenServiceImpl implements RefreshTokenService{
     }
 
     @Override
-    public void deleteByUserId (Long userId) {
+    public void deleteByUserId(Long userId) {
         UserAccount user = userAccountService.findById(userId)
-                    .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         refreshTokenRepository.deleteByUserAccount(user);
     }
@@ -74,17 +65,19 @@ public class RefreshTokenServiceImpl implements RefreshTokenService{
                 .flatMap(token -> {
                     if (!isValidRefreshToken(token)) {
                         deleteRefreshToken(token);
-                        return Optional.empty(); 
+                        return Optional.empty();
                     }
+
                     UserAccount user = token.getUserAccount();
+                    token.setRefreshToken(UUID.randomUUID().toString());
+                    token.refreshExpiryDate();
+                    refreshTokenRepository.save(token);
                     return Optional.of(jwtService.generateAccessToken(user));
                 });
     }
 
-	@Override
-	public void deleteRefreshToken(RefreshToken token) {
+    @Override
+    public void deleteRefreshToken(RefreshToken token) {
         refreshTokenRepository.delete(token);
-	}
-
-
+    }
 }

--- a/src/main/java/org/csps/backend/service/impl/SalesServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/SalesServiceImpl.java
@@ -12,17 +12,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.csps.backend.domain.dtos.request.OrderSearchDTO;
-import org.csps.backend.domain.dtos.request.StudentMembershipRequestDTO;
 import org.csps.backend.domain.dtos.response.sales.ChartPointDTO;
 import org.csps.backend.domain.dtos.response.sales.SalesStatsDTO;
 import org.csps.backend.domain.dtos.response.sales.TransactionDTO;
 import org.csps.backend.domain.entities.Order;
 import org.csps.backend.domain.entities.OrderItem;
+import org.csps.backend.domain.entities.StudentMembership;
 import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.domain.enums.SalesPeriod;
-import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.exception.InvalidOrderStatusTransitionException;
+import org.csps.backend.exception.InvalidRequestException;
 import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
 import org.csps.backend.repository.StudentMembershipRepository;
@@ -44,6 +44,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SalesServiceImpl implements SalesService {
 
+    private static final BigDecimal MEMBERSHIP_REVENUE_PER_MEMBER = BigDecimal.valueOf(100);
+    private static final List<OrderStatus> FINANCE_REVENUE_STATUSES =
+            List.of(OrderStatus.TO_BE_CLAIMED, OrderStatus.CLAIMED);
+
     private final OrderRepository orderRepository;
     private final OrderItemRepository orderItemRepository;
     private final OrderLifecycleService orderLifecycleService;
@@ -57,15 +61,16 @@ public class SalesServiceImpl implements SalesService {
     @Value("${csps.currentAcademicYear.end}")
     private int currentYearEnd;
 
-
     // Deployment date - set to today (February 8, 2026) as dummy data
     private static final LocalDate DEPLOYMENT_DATE = LocalDate.of(2026, 2, 25);
 
     @Override
     public SalesStatsDTO getSalesStats(SalesPeriod period) {
-        List<Order> claimedOrders = orderRepository.findByOrderStatus(OrderStatus.CLAIMED);
+        List<Order> financeOrders = orderRepository.findByOrderStatusIn(FINANCE_REVENUE_STATUSES);
+        List<StudentMembership> currentYearMemberships =
+                studentMembershipRepository.findByYearStartAndYearEnd(currentYearStart, currentYearEnd);
 
-        List<ChartPointDTO> chartData = generateChartData(claimedOrders, period);
+        List<ChartPointDTO> chartData = generateChartData(financeOrders, currentYearMemberships, period);
 
         // Calculate total sales from chart data (sum of all chart values)
         BigDecimal totalSales = chartData.stream()
@@ -114,25 +119,19 @@ public class SalesServiceImpl implements SalesService {
         }
 
         if (containsMembershipItem(order.getOrderItems())) {
-            StudentMembershipRequestDTO membershipRequest = StudentMembershipRequestDTO.builder()
-                    .studentId(order.getStudent().getStudentId())
-                    .yearStart(currentYearStart)
-                    .yearEnd(currentYearEnd)
-                    .build();
-
-            studentMembershipService.createStudentMembership(membershipRequest);
+            studentMembershipService.ensureMembershipForCurrentAcademicYear(order.getStudent().getStudentId());
         }
 
         for (OrderItem item : order.getOrderItems()) {
-            item.setOrderStatus(OrderStatus.TO_BE_CLAIMED);
+            item.setOrderStatus(resolveApprovedItemStatus(item));
             item.setUpdatedAt(LocalDateTime.now());
             orderItemRepository.save(item);
         }
 
-        order.setOrderStatus(OrderStatus.TO_BE_CLAIMED);
+        order.setOrderStatus(resolveOrderStatusAfterApproval(order));
         order.setUpdatedAt(LocalDateTime.now());
         Order savedOrder = orderRepository.save(order);
-        sendReadyToClaimNotifications(savedOrder.getOrderId());
+        sendApprovedItemNotifications(savedOrder.getOrderId());
 
         return mapToTransactionDTO(savedOrder, isActiveMember(savedOrder.getStudent().getStudentId()));
     }
@@ -189,56 +188,71 @@ public class SalesServiceImpl implements SalesService {
                 && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP);
     }
 
-    private void sendReadyToClaimNotifications(Long orderId) {
+    private void sendApprovedItemNotifications(Long orderId) {
         List<OrderItem> orderItems = orderItemRepository.findByOrderOrderId(orderId);
         for (OrderItem orderItem : orderItems) {
-            var notificationData = orderNotificationService.extractNotificationData(orderItem, OrderStatus.TO_BE_CLAIMED);
+            var notificationData = orderNotificationService.extractNotificationData(orderItem, orderItem.getOrderStatus());
             if (notificationData != null) {
                 orderNotificationService.sendOrderStatusEmail(notificationData);
             }
         }
     }
 
+    private OrderStatus resolveApprovedItemStatus(OrderItem item) {
+        if (item != null
+                && item.getMerchVariantItem() != null
+                && item.getMerchVariantItem().getMerchVariant() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP) {
+            return OrderStatus.CLAIMED;
+        }
+
+        return OrderStatus.TO_BE_CLAIMED;
+    }
+
+    private OrderStatus resolveOrderStatusAfterApproval(Order order) {
+        if (order == null || order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            return OrderStatus.PENDING;
+        }
+
+        boolean allClaimed = order.getOrderItems().stream().allMatch(item -> item.getOrderStatus() == OrderStatus.CLAIMED);
+        return allClaimed ? OrderStatus.CLAIMED : OrderStatus.TO_BE_CLAIMED;
+    }
+
     private boolean isActiveMember(String studentId) {
         return studentMembershipRepository.hasActiveMembership(studentId);
     }
 
-    private List<ChartPointDTO> generateChartData(List<Order> orders, SalesPeriod period) {
+    private List<ChartPointDTO> generateChartData(
+            List<Order> orders,
+            List<StudentMembership> memberships,
+            SalesPeriod period) {
         Map<String, BigDecimal> groupedData = new LinkedHashMap<>();
 
         orders.forEach(order -> {
-            if (order.getOrderDate() == null || order.getTotalPrice() == null) {
+            if (order.getOrderDate() == null) {
                 return;
             }
 
             LocalDate orderDate = order.getOrderDate().toLocalDate();
-            String key;
-
-            switch (period) {
-                case DAILY:
-                    key = orderDate.toString();
-                    break;
-                case WEEKLY:
-                    // Calculate weeks since deployment date
-                    long daysSinceDeployment = java.time.temporal.ChronoUnit.DAYS.between(DEPLOYMENT_DATE, orderDate);
-                    int weekSinceDeployment = (int) Math.ceil((daysSinceDeployment + 1.0) / 7.0);
-                    key = "Week " + Math.max(1, weekSinceDeployment);
-                    break;
-                case MONTHLY:
-                    key = orderDate.getMonth().toString() + " " + orderDate.getYear();
-                    break;
-                case YEARLY:
-                    key = String.valueOf(orderDate.getYear());
-                    break;
-                case ALL_TIME:
-                    key = "All Time";
-                    break;
-                default:
-                    key = orderDate.toString();
+            BigDecimal merchRevenue = calculateFinanceMerchRevenue(order);
+            if (merchRevenue.signum() == 0) {
+                return;
             }
 
-            groupedData.put(key, groupedData.getOrDefault(key, BigDecimal.ZERO)
-                    .add(BigDecimal.valueOf(order.getTotalPrice())));
+            String key = resolveChartKey(orderDate, period);
+            groupedData.put(key, groupedData.getOrDefault(key, BigDecimal.ZERO).add(merchRevenue));
+        });
+
+        memberships.forEach(membership -> {
+            if (membership.getDateJoined() == null) {
+                return;
+            }
+
+            String key = resolveChartKey(membership.getDateJoined().toLocalDate(), period);
+            groupedData.put(
+                    key,
+                    groupedData.getOrDefault(key, BigDecimal.ZERO).add(MEMBERSHIP_REVENUE_PER_MEMBER));
         });
 
         return groupedData.entrySet().stream()
@@ -247,6 +261,55 @@ public class SalesServiceImpl implements SalesService {
                         .value(entry.getValue())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private BigDecimal calculateFinanceMerchRevenue(Order order) {
+        if (order == null || order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        return order.getOrderItems().stream()
+                .filter(this::isFinanceRevenueItem)
+                .filter(item -> !isMembershipItem(item))
+                .map(this::calculateLineTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    private boolean isFinanceRevenueItem(OrderItem item) {
+        return item != null
+                && item.getOrderStatus() != null
+                && FINANCE_REVENUE_STATUSES.contains(item.getOrderStatus());
+    }
+
+    private boolean isMembershipItem(OrderItem item) {
+        return item != null
+                && item.getMerchVariantItem() != null
+                && item.getMerchVariantItem().getMerchVariant() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP;
+    }
+
+    private BigDecimal calculateLineTotal(OrderItem item) {
+        if (item == null || item.getPriceAtPurchase() == null || item.getQuantity() == null) {
+            return BigDecimal.ZERO;
+        }
+
+        return BigDecimal.valueOf(item.getPriceAtPurchase())
+                .multiply(BigDecimal.valueOf(item.getQuantity().longValue()));
+    }
+
+    private String resolveChartKey(LocalDate date, SalesPeriod period) {
+        return switch (period) {
+            case DAILY -> date.toString();
+            case WEEKLY -> {
+                long daysSinceDeployment = java.time.temporal.ChronoUnit.DAYS.between(DEPLOYMENT_DATE, date);
+                int weekSinceDeployment = (int) Math.ceil((daysSinceDeployment + 1.0) / 7.0);
+                yield "Week " + Math.max(1, weekSinceDeployment);
+            }
+            case MONTHLY -> date.getMonth().toString() + " " + date.getYear();
+            case YEARLY -> String.valueOf(date.getYear());
+            case ALL_TIME -> "All Time";
+        };
     }
 
     private OrderSearchDTO normalizeAndValidateSearch(OrderSearchDTO searchDTO) {

--- a/src/main/java/org/csps/backend/service/impl/SalesServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/SalesServiceImpl.java
@@ -3,9 +3,12 @@ package org.csps.backend.service.impl;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.csps.backend.domain.dtos.request.OrderSearchDTO;
@@ -18,10 +21,14 @@ import org.csps.backend.domain.entities.OrderItem;
 import org.csps.backend.domain.enums.MerchType;
 import org.csps.backend.domain.enums.OrderStatus;
 import org.csps.backend.domain.enums.SalesPeriod;
-import org.csps.backend.repository.MerchVariantItemRepository;
+import org.csps.backend.exception.InvalidRequestException;
+import org.csps.backend.exception.InvalidOrderStatusTransitionException;
 import org.csps.backend.repository.OrderItemRepository;
 import org.csps.backend.repository.OrderRepository;
+import org.csps.backend.repository.StudentMembershipRepository;
 import org.csps.backend.repository.specification.OrderSpecification;
+import org.csps.backend.service.OrderLifecycleService;
+import org.csps.backend.service.OrderNotificationService;
 import org.csps.backend.service.SalesService;
 import org.csps.backend.service.StudentMembershipService;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,9 +45,11 @@ import lombok.RequiredArgsConstructor;
 public class SalesServiceImpl implements SalesService {
 
     private final OrderRepository orderRepository;
-    private final MerchVariantItemRepository merchVariantItemRepository;
     private final OrderItemRepository orderItemRepository;
+    private final OrderLifecycleService orderLifecycleService;
     private final StudentMembershipService studentMembershipService;
+    private final StudentMembershipRepository studentMembershipRepository;
+    private final OrderNotificationService orderNotificationService;
 
     @Value("${csps.currentAcademicYear.start}")
     private int currentYearStart;
@@ -73,13 +82,15 @@ public class SalesServiceImpl implements SalesService {
     @Override
     public Page<TransactionDTO> getTransactions(Pageable pageable, OrderSearchDTO searchDTO) {
         /* build specification for database-level filtering to prevent loading all orders into memory */
-        Specification<Order> spec = OrderSpecification.withFilters(searchDTO);
+        OrderSearchDTO normalizedSearch = normalizeAndValidateSearch(searchDTO);
+        Specification<Order> spec = OrderSpecification.withFilters(normalizedSearch);
         
         /* fetch paginated results with eager loading via @EntityGraph in OrderRepository.findAll(pageable) */
         Page<Order> orders = orderRepository.findAll(spec, pageable);
-        
+        Set<String> activeMembershipStudentIds = resolveActiveMembershipStudentIds(orders.getContent());
+
         /* map orders to DTOs */
-        return orders.map(this::mapToTransactionDTO);
+        return orders.map(order -> mapToTransactionDTO(order, activeMembershipStudentIds.contains(order.getStudent().getStudentId())));
     }
 
 
@@ -90,43 +101,40 @@ public class SalesServiceImpl implements SalesService {
         Order order = orderRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Order not found"));
 
-        // Check for MEMBERSHIP items and create membership if found
-        if (order.getOrderItems() != null) {
-            boolean hasMembership = false;
-            for (OrderItem item : order.getOrderItems()) {
-                if (item.getMerchVariantItem() != null 
-                        && item.getMerchVariantItem().getMerchVariant() != null
-                        && item.getMerchVariantItem().getMerchVariant().getMerch() != null
-                        && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP) {
-                    hasMembership = true;
-                    break;
-                }
-            }
-
-            if (hasMembership) {
-                try {
-                    StudentMembershipRequestDTO membershipRequest = StudentMembershipRequestDTO.builder()
-                            .studentId(order.getStudent().getStudentId())
-                            .yearStart(currentYearStart)
-                            .yearEnd(currentYearEnd)
-                            .build();
-                    
-                    studentMembershipService.createStudentMembership(membershipRequest);
-                } catch (Exception e) {
-                    // Log error but proceed with order approval? Or fail?
-                    // For now, let's log and proceed, or maybe rethrow if strict
-                    System.err.println("Failed to create membership for order " + id + ": " + e.getMessage());
-                    // Decide: Should we fail the transaction if membership fails? 
-                    // Probably yes, to ensure consistency.
-                    throw new RuntimeException("Failed to create membership: " + e.getMessage(), e);
-                }
-            }
+        if (order.getOrderStatus() != OrderStatus.PENDING) {
+            throw new InvalidOrderStatusTransitionException("Only pending orders can be approved");
         }
 
-        order.setOrderStatus(OrderStatus.CLAIMED);
-        Order savedOrder = orderRepository.save(order);
+        if (order.getOrderItems() == null || order.getOrderItems().isEmpty()) {
+            throw new InvalidRequestException("Orders without items cannot be approved");
+        }
 
-        return mapToTransactionDTO(savedOrder);
+        if (order.getOrderItems().stream().anyMatch(item -> item.getOrderStatus() != OrderStatus.PENDING)) {
+            throw new InvalidOrderStatusTransitionException("Only orders with pending items can be approved");
+        }
+
+        if (containsMembershipItem(order.getOrderItems())) {
+            StudentMembershipRequestDTO membershipRequest = StudentMembershipRequestDTO.builder()
+                    .studentId(order.getStudent().getStudentId())
+                    .yearStart(currentYearStart)
+                    .yearEnd(currentYearEnd)
+                    .build();
+
+            studentMembershipService.createStudentMembership(membershipRequest);
+        }
+
+        for (OrderItem item : order.getOrderItems()) {
+            item.setOrderStatus(OrderStatus.TO_BE_CLAIMED);
+            item.setUpdatedAt(LocalDateTime.now());
+            orderItemRepository.save(item);
+        }
+
+        order.setOrderStatus(OrderStatus.TO_BE_CLAIMED);
+        order.setUpdatedAt(LocalDateTime.now());
+        Order savedOrder = orderRepository.save(order);
+        sendReadyToClaimNotifications(savedOrder.getOrderId());
+
+        return mapToTransactionDTO(savedOrder, isActiveMember(savedOrder.getStudent().getStudentId()));
     }
 
     @Override
@@ -135,30 +143,14 @@ public class SalesServiceImpl implements SalesService {
         Order order = orderRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Order not found"));
 
-        // Restore inventory for all order items in this order and reject them
-        if (order.getOrderItems() != null && !order.getOrderItems().isEmpty()) {
-            for (OrderItem orderItem : order.getOrderItems()) {
-                // Restore the quantity to the MerchVariantItem
-                var merchVariantItem = orderItem.getMerchVariantItem();
-                if (merchVariantItem != null) {
-                    Integer currentStock = merchVariantItem.getStockQuantity();
-                    int restoredStock = currentStock + orderItem.getQuantity();
-                    merchVariantItem.setStockQuantity(restoredStock);
-                    merchVariantItemRepository.save(merchVariantItem);
-                }
-                
-                // Set order item status to REJECTED
-                orderItem.setOrderStatus(OrderStatus.REJECTED);
-                orderItem.setUpdatedAt(LocalDateTime.now());
-                orderItemRepository.save(orderItem);
-            }
+        if (order.getOrderStatus() == OrderStatus.CANCELLED) {
+            throw new InvalidOrderStatusTransitionException("Cancelled orders cannot be rejected");
         }
 
-        order.setOrderStatus(OrderStatus.REJECTED);
-        orderRepository.save(order);
+        orderLifecycleService.applyTerminalStatus(order, OrderStatus.REJECTED);
     }
 
-    private TransactionDTO mapToTransactionDTO(Order order) {
+    private TransactionDTO mapToTransactionDTO(Order order, boolean activeMember) {
         String studentName = order.getStudent().getUserAccount().getUserProfile().getFirstName() + " " +
                 order.getStudent().getUserAccount().getUserProfile().getLastName();
 
@@ -168,11 +160,47 @@ public class SalesServiceImpl implements SalesService {
                 .studentId(order.getStudent().getStudentId())
                 .studentName(studentName)
                 .idNumber(order.getStudent().getStudentId())
-                .membershipType("Member") // Can be enhanced with actual membership data
+                .membershipType(activeMember ? "Member" : "Non-Member")
                 .amount(BigDecimal.valueOf(order.getTotalPrice()))
                 .date(order.getOrderDate().toLocalDate().toString())
                 .status(order.getOrderStatus().name())
                 .build();
+    }
+
+    private Set<String> resolveActiveMembershipStudentIds(List<Order> orders) {
+        Set<String> studentIds = orders.stream()
+                .map(Order::getStudent)
+                .filter(student -> student != null && student.getStudentId() != null)
+                .map(student -> student.getStudentId().trim())
+                .filter(studentId -> !studentId.isEmpty())
+                .collect(Collectors.toSet());
+
+        if (studentIds.isEmpty()) {
+            return Set.of();
+        }
+
+        return new HashSet<>(studentMembershipRepository.findActiveStudentIdsByStudentIdIn(studentIds));
+    }
+
+    private boolean containsMembershipItem(List<OrderItem> orderItems) {
+        return orderItems.stream().anyMatch(item -> item.getMerchVariantItem() != null
+                && item.getMerchVariantItem().getMerchVariant() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch() != null
+                && item.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.MEMBERSHIP);
+    }
+
+    private void sendReadyToClaimNotifications(Long orderId) {
+        List<OrderItem> orderItems = orderItemRepository.findByOrderOrderId(orderId);
+        for (OrderItem orderItem : orderItems) {
+            var notificationData = orderNotificationService.extractNotificationData(orderItem, OrderStatus.TO_BE_CLAIMED);
+            if (notificationData != null) {
+                orderNotificationService.sendOrderStatusEmail(notificationData);
+            }
+        }
+    }
+
+    private boolean isActiveMember(String studentId) {
+        return studentMembershipRepository.hasActiveMembership(studentId);
     }
 
     private List<ChartPointDTO> generateChartData(List<Order> orders, SalesPeriod period) {
@@ -219,5 +247,52 @@ public class SalesServiceImpl implements SalesService {
                         .value(entry.getValue())
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    private OrderSearchDTO normalizeAndValidateSearch(OrderSearchDTO searchDTO) {
+        OrderSearchDTO normalizedSearch = searchDTO == null ? new OrderSearchDTO() : searchDTO;
+
+        normalizedSearch.setStudentName(normalizeWhitespace(normalizedSearch.getStudentName()));
+        normalizedSearch.setStudentId(trimToNull(normalizedSearch.getStudentId()));
+        normalizedSearch.setStatus(normalizeStatus(normalizedSearch.getStatus()));
+
+        if (normalizedSearch.getStartDate() != null
+                && normalizedSearch.getEndDate() != null
+                && normalizedSearch.getEndDate().isBefore(normalizedSearch.getStartDate())) {
+            throw new InvalidRequestException("End date must be greater than or equal to start date");
+        }
+
+        if (normalizedSearch.getStatus() != null) {
+            try {
+                OrderStatus.valueOf(normalizedSearch.getStatus());
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidRequestException("Invalid order status: " + normalizedSearch.getStatus());
+            }
+        }
+
+        if (normalizedSearch.getYear() != null
+                && (normalizedSearch.getYear() < 1000 || normalizedSearch.getYear() > 9999)) {
+            throw new InvalidRequestException("Year filter must be a four-digit year");
+        }
+
+        return normalizedSearch;
+    }
+
+    private String normalizeStatus(String status) {
+        String trimmedStatus = trimToNull(status);
+        return trimmedStatus == null ? null : trimmedStatus.toUpperCase(Locale.ROOT);
+    }
+
+    private String normalizeWhitespace(String value) {
+        return value == null ? null : value.trim().replaceAll("\\s+", " ");
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/org/csps/backend/service/impl/StudentMembershipServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/StudentMembershipServiceImpl.java
@@ -100,6 +100,27 @@ public class StudentMembershipServiceImpl implements StudentMembershipService {
         return studentMembershipMapper.toResponseDTO(saved);
     }
 
+    @Override
+    @Transactional
+    public StudentMembershipResponseDTO ensureMembershipForCurrentAcademicYear(String studentId) {
+        if (studentId == null || studentId.isBlank()) {
+            throw new InvalidRequestException("Student ID is required");
+        }
+
+        Optional<StudentMembership> existingMembership = studentMembershipRepository
+                .findByStudentStudentIdAndYearStartAndYearEnd(studentId, currentYearStart, currentYearEnd);
+        if (existingMembership.isPresent()) {
+            return studentMembershipMapper.toResponseDTO(existingMembership.get());
+        }
+
+        StudentMembershipRequestDTO requestDTO = StudentMembershipRequestDTO.builder()
+                .studentId(studentId)
+                .yearStart(currentYearStart)
+                .yearEnd(currentYearEnd)
+                .build();
+        return createStudentMembership(requestDTO);
+    }
+
     /**
      * Retrieves all student memberships.
      *

--- a/src/main/java/org/csps/backend/service/impl/StudentServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/StudentServiceImpl.java
@@ -2,8 +2,8 @@ package org.csps.backend.service.impl;
 
 import java.util.Optional;
 
+import org.csps.backend.domain.dtos.request.StudentProfileCompletionRequestDTO;
 import org.csps.backend.domain.dtos.request.StudentRequestDTO;
-import org.csps.backend.domain.dtos.request.UserRequestDTO;
 import org.csps.backend.domain.dtos.response.StudentResponseDTO;
 import org.csps.backend.domain.entities.Admin;
 import org.csps.backend.domain.entities.Student;
@@ -142,7 +142,7 @@ public class StudentServiceImpl implements StudentService {
    
    @Override
    @Transactional
-   public StudentResponseDTO completeStudentProfile(String studentId, UserRequestDTO userRequestDTO) {
+   public StudentResponseDTO completeStudentProfile(String studentId, StudentProfileCompletionRequestDTO profileRequestDTO) {
        /* find student and validate existence */
        Student student = studentRepository.findById(studentId)
                .orElseThrow(() -> new StudentNotFoundException("Student not found: " + studentId));
@@ -151,9 +151,9 @@ public class StudentServiceImpl implements StudentService {
        UserProfile profile = student.getUserAccount().getUserProfile();
        
        /* update profile with complete information */
-       profile.setMiddleName(userRequestDTO.getMiddleName());
-       profile.setBirthDate(userRequestDTO.getBirthDate());
-       profile.setEmail(userRequestDTO.getEmail());
+    profile.setMiddleName(profileRequestDTO.getMiddleName());
+    profile.setBirthDate(profileRequestDTO.getBirthDate());
+    profile.setEmail(profileRequestDTO.getEmail());
        profile.setIsProfileComplete(true);  // mark as complete
        
        userProfileRepository.save(profile);

--- a/src/main/java/org/csps/backend/service/impl/TicketFreebieAssignmentServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/TicketFreebieAssignmentServiceImpl.java
@@ -1,0 +1,416 @@
+package org.csps.backend.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.csps.backend.domain.dtos.request.TicketFreebieAssignmentRequestDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieAssignmentResponseDTO;
+import org.csps.backend.domain.entities.OrderItem;
+import org.csps.backend.domain.entities.TicketFreebieAssignment;
+import org.csps.backend.domain.entities.TicketFreebieConfig;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.MerchType;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+import org.csps.backend.domain.enums.TicketFreebieFulfillmentStatus;
+import org.csps.backend.exception.InvalidRequestException;
+import org.csps.backend.exception.OrderItemNotFoundException;
+import org.csps.backend.mapper.TicketFreebieAssignmentMapper;
+import org.csps.backend.repository.OrderItemRepository;
+import org.csps.backend.repository.TicketFreebieAssignmentRepository;
+import org.csps.backend.repository.TicketFreebieConfigRepository;
+import org.csps.backend.service.TicketFreebieAssignmentService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketFreebieAssignmentServiceImpl implements TicketFreebieAssignmentService {
+
+    private final OrderItemRepository orderItemRepository;
+    private final TicketFreebieAssignmentRepository ticketFreebieAssignmentRepository;
+    private final TicketFreebieConfigRepository ticketFreebieConfigRepository;
+    private final TicketFreebieAssignmentMapper ticketFreebieAssignmentMapper;
+
+    @Override
+    @Transactional
+    public List<TicketFreebieAssignmentResponseDTO> initializeAssignments(Long orderItemId, List<TicketFreebieAssignmentRequestDTO> requests) {
+        OrderItem orderItem = getOrderItem(orderItemId);
+        TicketContext ticketContext = resolveTicketContext(orderItem);
+        if (!ticketContext.hasFreebie()) {
+            if (requests != null && !requests.isEmpty()) {
+                throw new InvalidRequestException("This order item does not support freebies");
+            }
+            return List.of(buildNoFreebieResponse(orderItemId));
+        }
+
+        return upsertAssignmentsInternal(orderItem, ticketContext, requests, true);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TicketFreebieAssignmentResponseDTO> getAssignmentsByOrderItemId(Long orderItemId) {
+        OrderItem orderItem = getOrderItem(orderItemId);
+        TicketContext ticketContext = resolveTicketContext(orderItem);
+        return buildResponses(
+                orderItemId,
+                ticketContext,
+                ticketFreebieAssignmentRepository.findByOrderItemOrderItemId(orderItemId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Map<Long, List<TicketFreebieAssignmentResponseDTO>> getAssignmentsByOrderItemIds(List<Long> orderItemIds) {
+        if (orderItemIds == null || orderItemIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Long> normalizedOrderItemIds = orderItemIds.stream()
+                .filter(orderItemId -> orderItemId != null && orderItemId > 0)
+                .distinct()
+                .toList();
+        if (normalizedOrderItemIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<OrderItem> orderItems = orderItemRepository.findByOrderItemIdIn(normalizedOrderItemIds);
+        Map<Long, OrderItem> orderItemsById = orderItems.stream()
+                .collect(Collectors.toMap(OrderItem::getOrderItemId, orderItem -> orderItem));
+        if (orderItemsById.size() != normalizedOrderItemIds.size()) {
+            throw new OrderItemNotFoundException("Order item not found");
+        }
+
+        List<TicketFreebieAssignment> assignments = ticketFreebieAssignmentRepository.findByOrderItemOrderItemIdIn(normalizedOrderItemIds);
+        Map<Long, List<TicketFreebieAssignment>> assignmentMap = assignments.stream()
+                .collect(Collectors.groupingBy(assignment -> assignment.getOrderItem().getOrderItemId()));
+
+        Map<Long, List<TicketFreebieConfig>> configsByMerchId = loadConfigsByMerchId(orderItems);
+        Map<Long, List<TicketFreebieAssignmentResponseDTO>> responseMap = new LinkedHashMap<>();
+        for (Long orderItemId : normalizedOrderItemIds) {
+            OrderItem orderItem = orderItemsById.get(orderItemId);
+            TicketContext ticketContext = resolveTicketContext(orderItem, configsByMerchId);
+            responseMap.put(
+                    orderItemId,
+                    buildResponses(orderItemId, ticketContext, assignmentMap.getOrDefault(orderItemId, List.of())));
+        }
+        return responseMap;
+    }
+
+    @Override
+    @Transactional
+    public List<TicketFreebieAssignmentResponseDTO> upsertAssignments(Long orderItemId, List<TicketFreebieAssignmentRequestDTO> requests) {
+        if (requests == null || requests.isEmpty()) {
+            throw new InvalidRequestException("Freebie assignment request is required");
+        }
+
+        OrderItem orderItem = getOrderItem(orderItemId);
+        TicketContext ticketContext = resolveTicketContext(orderItem);
+        if (!ticketContext.hasFreebie()) {
+            throw new InvalidRequestException("This order item does not support freebies");
+        }
+
+        return upsertAssignmentsInternal(orderItem, ticketContext, requests, false);
+    }
+
+    private List<TicketFreebieAssignmentResponseDTO> upsertAssignmentsInternal(
+            OrderItem orderItem,
+            TicketContext ticketContext,
+            List<TicketFreebieAssignmentRequestDTO> requests,
+            boolean allowEmptyForInitialize) {
+        List<TicketFreebieAssignmentRequestDTO> normalizedRequests = requests == null ? List.of() : requests;
+        Map<Long, TicketFreebieAssignmentRequestDTO> requestByConfigId = new LinkedHashMap<>();
+        for (TicketFreebieAssignmentRequestDTO request : normalizedRequests) {
+            if (request == null || request.getTicketFreebieConfigId() == null) {
+                throw new InvalidRequestException("Each freebie assignment must include ticketFreebieConfigId");
+            }
+            if (requestByConfigId.put(request.getTicketFreebieConfigId(), request) != null) {
+                throw new InvalidRequestException("Duplicate freebie assignments are not allowed for the same config");
+            }
+        }
+
+        Map<Long, TicketFreebieAssignment> existingByConfigId = ticketFreebieAssignmentRepository.findByOrderItemOrderItemId(orderItem.getOrderItemId()).stream()
+                .filter(assignment -> assignment.getTicketFreebieConfig() != null && assignment.getTicketFreebieConfig().getTicketFreebieConfigId() != null)
+                .collect(Collectors.toMap(assignment -> assignment.getTicketFreebieConfig().getTicketFreebieConfigId(), assignment -> assignment));
+
+        List<TicketFreebieAssignment> assignmentsToSave = new ArrayList<>();
+        for (TicketFreebieConfig config : ticketContext.configs()) {
+            TicketFreebieAssignmentRequestDTO request = requestByConfigId.remove(config.getTicketFreebieConfigId());
+            if (request == null) {
+                if (!allowEmptyForInitialize) {
+                    throw new InvalidRequestException("Missing freebie assignment for config " + config.getFreebieName());
+                }
+                request = TicketFreebieAssignmentRequestDTO.builder().ticketFreebieConfigId(config.getTicketFreebieConfigId()).build();
+            }
+
+            TicketFreebieAssignment assignment = existingByConfigId.getOrDefault(
+                    config.getTicketFreebieConfigId(),
+                    TicketFreebieAssignment.builder().orderItem(orderItem).ticketFreebieConfig(config).build());
+            assignment.setTicketFreebieConfig(config);
+            applyRequest(config, assignment, request);
+            assignmentsToSave.add(assignment);
+        }
+
+        if (!requestByConfigId.isEmpty()) {
+            throw new InvalidRequestException("Submitted freebie assignments contain unknown configs");
+        }
+
+        List<TicketFreebieAssignment> savedAssignments = ticketFreebieAssignmentRepository.saveAll(assignmentsToSave);
+        return ticketContext.configs().stream()
+                .map(config -> savedAssignments.stream()
+                        .filter(assignment -> config.getTicketFreebieConfigId().equals(assignment.getTicketFreebieConfig().getTicketFreebieConfigId()))
+                        .findFirst()
+                        .map(assignment -> buildResponse(config, assignment))
+                        .orElseGet(() -> buildPendingResponse(config, orderItem.getOrderItemId())))
+                .toList();
+    }
+
+    private void applyRequest(
+            TicketFreebieConfig config,
+            TicketFreebieAssignment assignment,
+            TicketFreebieAssignmentRequestDTO request) {
+        if (config.getCategory() == TicketFreebieCategory.CLOTHING) {
+            assignment.setSelectedSize(request.getSelectedSize());
+            assignment.setSelectedColor(normalizeOptionalText(request.getSelectedColor()));
+            assignment.setSelectedDesign(null);
+            validateClothingSelection(config, assignment);
+        } else {
+            assignment.setSelectedSize(null);
+            assignment.setSelectedColor(null);
+            assignment.setSelectedDesign(normalizeOptionalText(request.getSelectedDesign()));
+            validateNonClothingSelection(config, assignment);
+        }
+
+        boolean detailsComplete = hasCompleteDetails(config, assignment);
+        TicketFreebieFulfillmentStatus requestedStatus = request.getFulfillmentStatus();
+        TicketFreebieFulfillmentStatus resolvedStatus = resolveStatus(assignment, requestedStatus, detailsComplete);
+        assignment.setFulfillmentStatus(resolvedStatus);
+        syncTimestamps(assignment, resolvedStatus);
+    }
+
+    private TicketFreebieFulfillmentStatus resolveStatus(
+            TicketFreebieAssignment assignment,
+            TicketFreebieFulfillmentStatus requestedStatus,
+            boolean detailsComplete) {
+        if (requestedStatus != null) {
+            validateStatus(detailsComplete, requestedStatus);
+            return requestedStatus;
+        }
+
+        if (!detailsComplete) {
+            return TicketFreebieFulfillmentStatus.PENDING_DETAILS;
+        }
+
+        if (assignment.getFulfillmentStatus() == TicketFreebieFulfillmentStatus.CLAIMED
+                || assignment.getFulfillmentStatus() == TicketFreebieFulfillmentStatus.FULFILLED) {
+            return assignment.getFulfillmentStatus();
+        }
+
+        return TicketFreebieFulfillmentStatus.DETAILS_COMPLETED;
+    }
+
+    private void validateStatus(boolean detailsComplete, TicketFreebieFulfillmentStatus status) {
+        if (status == TicketFreebieFulfillmentStatus.NO_FREEBIE) {
+            throw new InvalidRequestException("NO_FREEBIE is only allowed for tickets without freebies");
+        }
+
+        if ((status == TicketFreebieFulfillmentStatus.DETAILS_COMPLETED
+                || status == TicketFreebieFulfillmentStatus.CLAIMED
+                || status == TicketFreebieFulfillmentStatus.FULFILLED) && !detailsComplete) {
+            throw new InvalidRequestException("Freebie details must be complete before using status " + status);
+        }
+    }
+
+    private void syncTimestamps(TicketFreebieAssignment assignment, TicketFreebieFulfillmentStatus status) {
+        LocalDateTime now = LocalDateTime.now();
+        if (status == TicketFreebieFulfillmentStatus.CLAIMED || status == TicketFreebieFulfillmentStatus.FULFILLED) {
+            if (assignment.getClaimedAt() == null) {
+                assignment.setClaimedAt(now);
+            }
+        } else {
+            assignment.setClaimedAt(null);
+        }
+
+        if (status == TicketFreebieFulfillmentStatus.FULFILLED) {
+            if (assignment.getFulfilledAt() == null) {
+                assignment.setFulfilledAt(now);
+            }
+        } else {
+            assignment.setFulfilledAt(null);
+        }
+    }
+
+    private void validateClothingSelection(TicketFreebieConfig config, TicketFreebieAssignment assignment) {
+        Set<ClothingSizing> allowedSizes = config.getSizeOptions().stream().map(option -> option.getSizeLabel()).collect(Collectors.toSet());
+        Set<String> allowedColors = config.getColorOptions().stream()
+                .map(option -> option.getColorLabel().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+
+        if (assignment.getSelectedSize() != null && !allowedSizes.contains(assignment.getSelectedSize())) {
+            throw new InvalidRequestException("Selected size is not allowed for " + config.getFreebieName());
+        }
+        if (assignment.getSelectedColor() != null
+                && !allowedColors.contains(assignment.getSelectedColor().toLowerCase(Locale.ROOT))) {
+            throw new InvalidRequestException("Selected color is not allowed for " + config.getFreebieName());
+        }
+    }
+
+    private void validateNonClothingSelection(TicketFreebieConfig config, TicketFreebieAssignment assignment) {
+        Set<String> allowedDesigns = config.getDesignOptions().stream()
+                .map(option -> option.getDesignLabel().toLowerCase(Locale.ROOT))
+                .collect(Collectors.toSet());
+        if (assignment.getSelectedDesign() != null
+                && !allowedDesigns.contains(assignment.getSelectedDesign().toLowerCase(Locale.ROOT))) {
+            throw new InvalidRequestException("Selected design is not allowed for " + config.getFreebieName());
+        }
+    }
+
+    private boolean hasCompleteDetails(TicketFreebieConfig config, TicketFreebieAssignment assignment) {
+        if (config.getCategory() == TicketFreebieCategory.CLOTHING) {
+            return assignment.getSelectedSize() != null && assignment.getSelectedColor() != null;
+        }
+        return assignment.getSelectedDesign() != null;
+    }
+
+    private TicketContext resolveTicketContext(OrderItem orderItem) {
+        return resolveTicketContext(orderItem, null);
+    }
+
+    private TicketContext resolveTicketContext(
+            OrderItem orderItem,
+            Map<Long, List<TicketFreebieConfig>> configsByMerchId) {
+        if (orderItem.getMerchVariantItem() == null
+                || orderItem.getMerchVariantItem().getMerchVariant() == null
+                || orderItem.getMerchVariantItem().getMerchVariant().getMerch() == null) {
+            throw new InvalidRequestException("Order item merch details are incomplete");
+        }
+
+        MerchType merchType = orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType();
+        if (merchType != MerchType.TICKET) {
+            return new TicketContext(false, List.of());
+        }
+
+        boolean hasFreebie = Boolean.TRUE.equals(orderItem.getMerchVariantItem().getMerchVariant().getMerch().getHasFreebie());
+        if (!hasFreebie) {
+            return new TicketContext(false, List.of());
+        }
+
+        Long ticketMerchId = orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchId();
+        List<TicketFreebieConfig> configs = configsByMerchId == null
+                ? ticketFreebieConfigRepository.findByTicketMerchMerchIdOrderByDisplayOrderAscTicketFreebieConfigIdAsc(ticketMerchId)
+                : configsByMerchId.getOrDefault(ticketMerchId, List.of());
+        if (configs.isEmpty()) {
+            throw new InvalidRequestException("Ticket freebie config is missing for merch id: " + ticketMerchId);
+        }
+        return new TicketContext(true, configs);
+    }
+
+    private Map<Long, List<TicketFreebieConfig>> loadConfigsByMerchId(List<OrderItem> orderItems) {
+        List<Long> merchIds = orderItems.stream()
+                .filter(orderItem -> orderItem.getMerchVariantItem() != null
+                        && orderItem.getMerchVariantItem().getMerchVariant() != null
+                        && orderItem.getMerchVariantItem().getMerchVariant().getMerch() != null
+                        && orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchType() == MerchType.TICKET
+                        && Boolean.TRUE.equals(orderItem.getMerchVariantItem().getMerchVariant().getMerch().getHasFreebie()))
+                .map(orderItem -> orderItem.getMerchVariantItem().getMerchVariant().getMerch().getMerchId())
+                .distinct()
+                .toList();
+        if (merchIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return ticketFreebieConfigRepository
+                .findByTicketMerchMerchIdInOrderByTicketMerchMerchIdAscDisplayOrderAscTicketFreebieConfigIdAsc(merchIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        config -> config.getTicketMerch().getMerchId(),
+                        LinkedHashMap::new,
+                        Collectors.toList()));
+    }
+
+    private OrderItem getOrderItem(Long orderItemId) {
+        if (orderItemId == null || orderItemId <= 0) {
+            throw new InvalidRequestException("Order item ID is required");
+        }
+        return orderItemRepository.findByIdWithStudentAndMerchDetails(orderItemId)
+                .orElseThrow(() -> new OrderItemNotFoundException("Order item not found"));
+    }
+
+    private TicketFreebieAssignmentResponseDTO buildResponse(TicketFreebieConfig config, TicketFreebieAssignment assignment) {
+        TicketFreebieAssignmentResponseDTO response = ticketFreebieAssignmentMapper.toResponseDTO(assignment);
+        enrichResponse(response, config);
+        return response;
+    }
+
+    private TicketFreebieAssignmentResponseDTO buildPendingResponse(TicketFreebieConfig config, Long orderItemId) {
+        TicketFreebieAssignmentResponseDTO response = TicketFreebieAssignmentResponseDTO.builder()
+                .orderItemId(orderItemId)
+                .ticketFreebieConfigId(config.getTicketFreebieConfigId())
+                .fulfillmentStatus(TicketFreebieFulfillmentStatus.PENDING_DETAILS)
+                .build();
+        enrichResponse(response, config);
+        return response;
+    }
+
+    private TicketFreebieAssignmentResponseDTO buildNoFreebieResponse(Long orderItemId) {
+        return TicketFreebieAssignmentResponseDTO.builder()
+                .orderItemId(orderItemId)
+                .hasFreebie(false)
+                .fulfillmentStatus(TicketFreebieFulfillmentStatus.NO_FREEBIE)
+                .build();
+    }
+
+    private List<TicketFreebieAssignmentResponseDTO> buildResponses(
+            Long orderItemId,
+            TicketContext ticketContext,
+            List<TicketFreebieAssignment> assignments) {
+        if (!ticketContext.hasFreebie()) {
+            return List.of(buildNoFreebieResponse(orderItemId));
+        }
+
+        Map<Long, TicketFreebieAssignment> assignmentsByConfigId = assignments.stream()
+                .filter(assignment -> assignment.getTicketFreebieConfig() != null
+                        && assignment.getTicketFreebieConfig().getTicketFreebieConfigId() != null)
+                .collect(Collectors.toMap(
+                        assignment -> assignment.getTicketFreebieConfig().getTicketFreebieConfigId(),
+                        assignment -> assignment));
+
+        return ticketContext.configs().stream()
+                .map(config -> {
+                    TicketFreebieAssignment assignment = assignmentsByConfigId.get(config.getTicketFreebieConfigId());
+                    return assignment == null
+                            ? buildPendingResponse(config, orderItemId)
+                            : buildResponse(config, assignment);
+                })
+                .toList();
+    }
+
+    private void enrichResponse(TicketFreebieAssignmentResponseDTO response, TicketFreebieConfig config) {
+        response.setHasFreebie(true);
+        response.setTicketFreebieConfigId(config.getTicketFreebieConfigId());
+        response.setCategory(config.getCategory());
+        response.setFreebieName(config.getFreebieName());
+        response.setClothingSubtype(config.getClothingSubtype());
+        response.setAllowedSizes(config.getSizeOptions().stream().map(option -> option.getSizeLabel()).toList());
+        response.setAllowedColors(config.getColorOptions().stream().map(option -> option.getColorLabel()).toList());
+        response.setAllowedDesigns(config.getDesignOptions().stream().map(option -> option.getDesignLabel()).toList());
+    }
+
+    private String normalizeOptionalText(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        String normalized = rawValue.trim().replaceAll("\\s+", " ");
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private record TicketContext(boolean hasFreebie, List<TicketFreebieConfig> configs) {
+    }
+}

--- a/src/main/java/org/csps/backend/service/impl/TicketFreebieConfigServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/TicketFreebieConfigServiceImpl.java
@@ -1,0 +1,372 @@
+package org.csps.backend.service.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.csps.backend.domain.dtos.request.TicketFreebieConfigRequestDTO;
+import org.csps.backend.domain.dtos.response.TicketFreebieConfigResponseDTO;
+import org.csps.backend.domain.entities.Merch;
+import org.csps.backend.domain.entities.MerchVariantItem;
+import org.csps.backend.domain.entities.TicketFreebieColorOption;
+import org.csps.backend.domain.entities.TicketFreebieConfig;
+import org.csps.backend.domain.entities.TicketFreebieDesignOption;
+import org.csps.backend.domain.entities.TicketFreebieSizeOption;
+import org.csps.backend.domain.enums.ClothingSizing;
+import org.csps.backend.domain.enums.MerchType;
+import org.csps.backend.domain.enums.TicketFreebieCategory;
+import org.csps.backend.exception.InvalidRequestException;
+import org.csps.backend.exception.MerchVariantNotFoundException;
+import org.csps.backend.mapper.TicketFreebieConfigMapper;
+import org.csps.backend.repository.CartItemFreebieSelectionRepository;
+import org.csps.backend.repository.MerchVariantItemRepository;
+import org.csps.backend.repository.OrderItemRepository;
+import org.csps.backend.repository.TicketFreebieAssignmentRepository;
+import org.csps.backend.repository.TicketFreebieConfigRepository;
+import org.csps.backend.service.TicketFreebieConfigService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketFreebieConfigServiceImpl implements TicketFreebieConfigService {
+
+    private final TicketFreebieConfigRepository ticketFreebieConfigRepository;
+    private final TicketFreebieAssignmentRepository ticketFreebieAssignmentRepository;
+    private final TicketFreebieConfigMapper ticketFreebieConfigMapper;
+    private final OrderItemRepository orderItemRepository;
+    private final MerchVariantItemRepository merchVariantItemRepository;
+    private final CartItemFreebieSelectionRepository cartItemFreebieSelectionRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TicketFreebieConfigResponseDTO> getConfigsByTicketMerchId(Long ticketMerchId) {
+        return ticketFreebieConfigRepository.findByTicketMerchMerchIdOrderByDisplayOrderAscTicketFreebieConfigIdAsc(ticketMerchId).stream()
+                .map(ticketFreebieConfigMapper::toResponseDTO)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TicketFreebieConfigResponseDTO> getConfigsByMerchVariantItemId(Long merchVariantItemId) {
+        MerchVariantItem merchVariantItem = merchVariantItemRepository.findById(merchVariantItemId)
+                .orElseThrow(() -> new MerchVariantNotFoundException("Merch variant item not found"));
+        return getConfigsByTicketMerchId(merchVariantItem.getMerchVariant().getMerch().getMerchId());
+    }
+
+    @Override
+    @Transactional
+    public void syncConfigsForMerch(Merch merch, Boolean hasFreebie, List<TicketFreebieConfigRequestDTO> requests) {
+        boolean shouldHaveFreebies = Boolean.TRUE.equals(hasFreebie);
+        List<TicketFreebieConfig> existingConfigs =
+                new ArrayList<>(ticketFreebieConfigRepository.findByTicketMerchMerchIdOrderByDisplayOrderAscTicketFreebieConfigIdAsc(merch.getMerchId()));
+        List<TicketFreebieConfigRequestDTO> normalizedRequests = requests == null ? List.of() : requests;
+
+        if (merch.getMerchType() != MerchType.TICKET) {
+            if (shouldHaveFreebies || !normalizedRequests.isEmpty() || !existingConfigs.isEmpty()) {
+                throw new InvalidRequestException("Freebie configuration is only allowed for ticket merchandise");
+            }
+            merch.setHasFreebie(false);
+            return;
+        }
+
+        boolean hasDependentCartSelections =
+                cartItemFreebieSelectionRepository.existsByTicketFreebieConfigTicketMerchMerchId(merch.getMerchId());
+
+        if (!shouldHaveFreebies) {
+            if (!normalizedRequests.isEmpty()) {
+                throw new InvalidRequestException("Freebie configs must not be submitted when hasFreebie is false");
+            }
+            if (!existingConfigs.isEmpty()) {
+                if (orderItemRepository.existsByMerch(merch.getMerchId()) || hasDependentCartSelections) {
+                    throw new InvalidRequestException("Cannot disable freebies for a ticket that already has buyers or active cart selections");
+                }
+                ticketFreebieConfigRepository.deleteAll(existingConfigs);
+            }
+            merch.setHasFreebie(false);
+            return;
+        }
+
+        if (normalizedRequests.isEmpty()) {
+            if (existingConfigs.isEmpty()) {
+                throw new InvalidRequestException("At least one freebie config is required when hasFreebie is true");
+            }
+            merch.setHasFreebie(true);
+            return;
+        }
+
+        merch.setHasFreebie(true);
+        boolean hasDependentOrders = orderItemRepository.existsByMerch(merch.getMerchId());
+        boolean hasDependentSelections = hasDependentOrders || hasDependentCartSelections;
+        Map<Long, TicketFreebieConfig> existingById = existingConfigs.stream()
+                .filter(config -> config.getTicketFreebieConfigId() != null)
+                .collect(LinkedHashMap::new, (map, config) -> map.put(config.getTicketFreebieConfigId(), config), Map::putAll);
+        Set<Long> retainedIds = new LinkedHashSet<>();
+        List<TicketFreebieConfig> configsToSave = new ArrayList<>();
+
+        int index = 0;
+        for (TicketFreebieConfigRequestDTO request : normalizedRequests) {
+            ValidatedFreebieConfig validated = validateAndNormalize(request, index);
+            TicketFreebieConfig config = null;
+            if (validated.configId() != null) {
+                config = existingById.get(validated.configId());
+                if (config == null) {
+                    throw new InvalidRequestException("Freebie config does not belong to this merch: " + validated.configId());
+                }
+            }
+
+            if (config == null) {
+                config = TicketFreebieConfig.builder()
+                        .ticketMerch(merch)
+                        .build();
+            } else if (hasDependentSelections) {
+                validateCategoryAndOptionSafety(config, validated);
+                retainedIds.add(config.getTicketFreebieConfigId());
+            }
+
+            config.setTicketMerch(merch);
+            config.setDisplayOrder(validated.displayOrder());
+            config.setCategory(validated.category());
+            config.setFreebieName(validated.freebieName());
+            config.setClothingSubtype(validated.clothingSubtype());
+            replaceOptions(config, validated);
+            configsToSave.add(config);
+            index++;
+        }
+
+        if (hasDependentSelections) {
+            for (TicketFreebieConfig existingConfig : existingConfigs) {
+                if (existingConfig.getTicketFreebieConfigId() != null && !retainedIds.contains(existingConfig.getTicketFreebieConfigId())) {
+                    throw new InvalidRequestException("Cannot remove a freebie config after buyers or active cart selections already exist for this ticket");
+                }
+            }
+        } else {
+            // Flush deletions before inserts so replacement writes do not race old rows inside
+            // the same transaction when the database still enforces older uniqueness assumptions.
+            ticketFreebieConfigRepository.deleteAll(existingConfigs);
+            ticketFreebieConfigRepository.flush();
+        }
+
+        ticketFreebieConfigRepository.saveAll(configsToSave);
+    }
+
+    private ValidatedFreebieConfig validateAndNormalize(TicketFreebieConfigRequestDTO request, int fallbackOrder) {
+        if (request == null) {
+            throw new InvalidRequestException("Freebie config entries must not be null");
+        }
+
+        String freebieName = normalizeRequiredText(request.getFreebieName(), "Freebie name is required");
+        String clothingSubtype = normalizeOptionalText(request.getClothingSubtype());
+        TicketFreebieCategory category = request.getCategory();
+        if (category == null) {
+            throw new InvalidRequestException("Freebie category is required");
+        }
+
+        int displayOrder = request.getDisplayOrder() == null ? fallbackOrder : request.getDisplayOrder();
+        if (displayOrder < 0) {
+            throw new InvalidRequestException("Freebie display order must be non-negative");
+        }
+
+        List<ClothingSizing> sizes = List.of();
+        List<String> colors = List.of();
+        List<String> designs = List.of();
+
+        if (category == TicketFreebieCategory.CLOTHING) {
+            sizes = normalizeSizes(request.getSizes());
+            colors = normalizeTextList(request.getColors(), "At least one color is required");
+            if (request.getDesigns() != null && !request.getDesigns().isEmpty()) {
+                throw new InvalidRequestException("Designs are not allowed for clothing freebies");
+            }
+        } else {
+            designs = normalizeTextList(request.getDesigns(), "At least one design or variant is required");
+            if (request.getSizes() != null && !request.getSizes().isEmpty()) {
+                throw new InvalidRequestException("Sizes are not allowed for non-clothing freebies");
+            }
+            if (request.getColors() != null && !request.getColors().isEmpty()) {
+                throw new InvalidRequestException("Colors are not allowed for non-clothing freebies");
+            }
+            clothingSubtype = null;
+        }
+
+        return new ValidatedFreebieConfig(request.getTicketFreebieConfigId(), displayOrder, category, freebieName, clothingSubtype, sizes, colors, designs);
+    }
+
+    private void validateCategoryAndOptionSafety(TicketFreebieConfig existingConfig, ValidatedFreebieConfig validated) {
+        if (existingConfig.getCategory() != validated.category()) {
+            throw new InvalidRequestException("Cannot change freebie category after buyers or active cart selections already exist for this ticket");
+        }
+
+        Set<ClothingSizing> newSizes = new LinkedHashSet<>(validated.sizes());
+        for (TicketFreebieSizeOption option : existingConfig.getSizeOptions()) {
+            if (!newSizes.contains(option.getSizeLabel()) && isSizeInUse(existingConfig.getTicketFreebieConfigId(), option.getSizeLabel())) {
+                throw new InvalidRequestException("Cannot remove size " + option.getSizeLabel() + " because it is already in use");
+            }
+        }
+
+        Set<String> newColors = lowercaseSet(validated.colors());
+        for (TicketFreebieColorOption option : existingConfig.getColorOptions()) {
+            if (!newColors.contains(option.getColorLabel().toLowerCase(Locale.ROOT))
+                    && isColorInUse(existingConfig.getTicketFreebieConfigId(), option.getColorLabel())) {
+                throw new InvalidRequestException("Cannot remove color " + option.getColorLabel() + " because it is already in use");
+            }
+        }
+
+        Set<String> newDesigns = lowercaseSet(validated.designs());
+        for (TicketFreebieDesignOption option : existingConfig.getDesignOptions()) {
+            if (!newDesigns.contains(option.getDesignLabel().toLowerCase(Locale.ROOT))
+                    && isDesignInUse(existingConfig.getTicketFreebieConfigId(), option.getDesignLabel())) {
+                throw new InvalidRequestException("Cannot remove design " + option.getDesignLabel() + " because it is already in use");
+            }
+        }
+    }
+
+    private boolean isSizeInUse(Long configId, ClothingSizing size) {
+        return ticketFreebieAssignmentRepository.countByConfigIdAndSelectedSize(configId, size) > 0
+                || cartItemFreebieSelectionRepository.countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedSize(configId, size) > 0;
+    }
+
+    private boolean isColorInUse(Long configId, String color) {
+        return ticketFreebieAssignmentRepository.countByConfigIdAndSelectedColor(configId, color) > 0
+                || cartItemFreebieSelectionRepository.countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedColorIgnoreCase(configId, color) > 0;
+    }
+
+    private boolean isDesignInUse(Long configId, String design) {
+        return ticketFreebieAssignmentRepository.countByConfigIdAndSelectedDesign(configId, design) > 0
+                || cartItemFreebieSelectionRepository.countByTicketFreebieConfigTicketFreebieConfigIdAndSelectedDesignIgnoreCase(configId, design) > 0;
+    }
+
+    private void replaceOptions(TicketFreebieConfig config, ValidatedFreebieConfig validated) {
+        syncSizeOptions(config, validated.sizes());
+        syncColorOptions(config, validated.colors());
+        syncDesignOptions(config, validated.designs());
+    }
+
+    private void syncSizeOptions(TicketFreebieConfig config, List<ClothingSizing> desiredSizes) {
+        Set<ClothingSizing> desired = new LinkedHashSet<>(desiredSizes);
+        config.getSizeOptions().removeIf(option -> !desired.contains(option.getSizeLabel()));
+
+        Set<ClothingSizing> existing = config.getSizeOptions().stream()
+                .map(TicketFreebieSizeOption::getSizeLabel)
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+
+        for (ClothingSizing size : desiredSizes) {
+            if (!existing.contains(size)) {
+                config.getSizeOptions().add(TicketFreebieSizeOption.builder()
+                        .ticketFreebieConfig(config)
+                        .sizeLabel(size)
+                        .build());
+            }
+        }
+    }
+
+    private void syncColorOptions(TicketFreebieConfig config, List<String> desiredColors) {
+        Set<String> desiredLower = lowercaseSet(desiredColors);
+        config.getColorOptions().removeIf(option -> !desiredLower.contains(option.getColorLabel().toLowerCase(Locale.ROOT)));
+
+        Set<String> existingLower = config.getColorOptions().stream()
+                .map(option -> option.getColorLabel().toLowerCase(Locale.ROOT))
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+
+        for (String color : desiredColors) {
+            String lowered = color.toLowerCase(Locale.ROOT);
+            if (!existingLower.contains(lowered)) {
+                config.getColorOptions().add(TicketFreebieColorOption.builder()
+                        .ticketFreebieConfig(config)
+                        .colorLabel(color)
+                        .build());
+            }
+        }
+    }
+
+    private void syncDesignOptions(TicketFreebieConfig config, List<String> desiredDesigns) {
+        Set<String> desiredLower = lowercaseSet(desiredDesigns);
+        config.getDesignOptions().removeIf(option -> !desiredLower.contains(option.getDesignLabel().toLowerCase(Locale.ROOT)));
+
+        Set<String> existingLower = config.getDesignOptions().stream()
+                .map(option -> option.getDesignLabel().toLowerCase(Locale.ROOT))
+                .collect(LinkedHashSet::new, Set::add, Set::addAll);
+
+        for (String design : desiredDesigns) {
+            String lowered = design.toLowerCase(Locale.ROOT);
+            if (!existingLower.contains(lowered)) {
+                config.getDesignOptions().add(TicketFreebieDesignOption.builder()
+                        .ticketFreebieConfig(config)
+                        .designLabel(design)
+                        .build());
+            }
+        }
+    }
+
+    private List<ClothingSizing> normalizeSizes(List<ClothingSizing> rawSizes) {
+        if (rawSizes == null || rawSizes.isEmpty()) {
+            throw new InvalidRequestException("At least one size is required");
+        }
+        Set<ClothingSizing> seen = new LinkedHashSet<>();
+        for (ClothingSizing size : rawSizes) {
+            if (size == null) {
+                throw new InvalidRequestException("Size values must not be empty");
+            }
+            if (!seen.add(size)) {
+                throw new InvalidRequestException("Duplicate size values are not allowed: " + size);
+            }
+        }
+        return new ArrayList<>(seen);
+    }
+
+    private List<String> normalizeTextList(List<String> rawValues, String emptyMessage) {
+        if (rawValues == null || rawValues.isEmpty()) {
+            throw new InvalidRequestException(emptyMessage);
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        List<String> normalizedValues = new ArrayList<>();
+        for (String rawValue : rawValues) {
+            String normalized = normalizeRequiredText(rawValue, "Freebie option values must not be empty");
+            if (!seen.add(normalized.toLowerCase(Locale.ROOT))) {
+                throw new InvalidRequestException("Duplicate freebie option values are not allowed: " + normalized);
+            }
+            normalizedValues.add(normalized);
+        }
+        return normalizedValues;
+    }
+
+    private Set<String> lowercaseSet(List<String> values) {
+        Set<String> lowered = new LinkedHashSet<>();
+        for (String value : values) {
+            lowered.add(value.toLowerCase(Locale.ROOT));
+        }
+        return lowered;
+    }
+
+    private String normalizeRequiredText(String rawValue, String message) {
+        String normalized = normalizeOptionalText(rawValue);
+        if (normalized == null) {
+            throw new InvalidRequestException(message);
+        }
+        return normalized;
+    }
+
+    private String normalizeOptionalText(String rawValue) {
+        if (rawValue == null) {
+            return null;
+        }
+        String normalized = rawValue.trim().replaceAll("\\s+", " ");
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private record ValidatedFreebieConfig(
+            Long configId,
+            Integer displayOrder,
+            TicketFreebieCategory category,
+            String freebieName,
+            String clothingSubtype,
+            List<ClothingSizing> sizes,
+            List<String> colors,
+            List<String> designs) {
+    }
+}

--- a/src/main/java/org/csps/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/UserServiceImpl.java
@@ -109,7 +109,7 @@ public class UserServiceImpl implements UserService {
 
         String tempPassword = String.format("%s%s", passwordFormat, studentId);
         userAccount.setPassword(passwordEncoder.encode(tempPassword)); // Hash the password
-        userAccount.setUsername(String.format("%s-%s", userNameFormat, studentId));
+        userAccount.setUsername(String.format("%s%s", userNameFormat, studentId));
         userAccount.setRole(UserRole.STUDENT);
 
         

--- a/src/main/java/org/csps/backend/service/impl/UserServiceImpl.java
+++ b/src/main/java/org/csps/backend/service/impl/UserServiceImpl.java
@@ -5,15 +5,18 @@ import java.util.List;
 import org.csps.backend.domain.dtos.request.ChangePasswordRequestDTO;
 import org.csps.backend.domain.dtos.request.StudentRequestDTO;
 import org.csps.backend.domain.dtos.request.UserRequestDTO;
+import org.csps.backend.domain.entities.Student;
 import org.csps.backend.domain.dtos.response.UserResponseDTO;
 import org.csps.backend.domain.entities.UserAccount;
 import org.csps.backend.domain.entities.UserProfile;
 import org.csps.backend.domain.enums.UserRole;
 import org.csps.backend.exception.EmailAlreadyExistsException;
 import org.csps.backend.exception.MissingFieldException;
+import org.csps.backend.exception.StudentNotFoundException;
 import org.csps.backend.exception.UserAlreadyExistsException;
 import org.csps.backend.exception.UserNotFoundException;
 import org.csps.backend.mapper.UserMapper;
+import org.csps.backend.repository.StudentRepository;
 import org.csps.backend.repository.UserAccountRepository;
 import org.csps.backend.repository.UserProfileRepository;
 import org.csps.backend.service.UserService;
@@ -29,6 +32,7 @@ public class UserServiceImpl implements UserService {
     private final UserMapper userMapper;
     private final UserAccountRepository userAccountRepository;
     private final UserProfileRepository userProfileRepository;
+    private final StudentRepository studentRepository;
     
     private final PasswordEncoder passwordEncoder;
     
@@ -141,6 +145,25 @@ public class UserServiceImpl implements UserService {
 
         user.setPassword(passwordEncoder.encode(requestDTO.getNewPassword()));
         userAccountRepository.save(user);
+    }
+
+    @Override
+    public void restoreStudentPassword(String studentId) {
+        if (studentId == null || studentId.isBlank()) {
+            throw new MissingFieldException("Student ID cannot be empty!");
+        }
+
+        Student student = studentRepository.findByStudentId(studentId.trim())
+                .orElseThrow(() -> new StudentNotFoundException("Student not found: " + studentId));
+
+        UserAccount userAccount = student.getUserAccount();
+        if (userAccount == null || userAccount.getUserAccountId() == null) {
+            throw new UserNotFoundException("User account not found for student: " + studentId);
+        }
+
+        String defaultPassword = passwordFormat + student.getStudentId();
+        userAccount.setPassword(passwordEncoder.encode(defaultPassword));
+        userAccountRepository.save(userAccount);
     }
 
 }


### PR DESCRIPTION
This PR delivers two backend improvements in the student purchase/profile flow:

Adds end-to-end ticket freebie support across merch, cart, order, and finance paths.
Fixes student profile completion validation so first/last name are not required for the complete-profile endpoint.
Changes Included
1) Ticket Freebies Flow
Added backend support to persist cart-level freebie selections.
Extended cart/order processing so freebie data is carried through checkout and related workflows.
Updated controller/service/repository layers to expose and process freebie-related behavior consistently.
Added supporting domain/service/repository components for freebie assignment/config integration used by the flow.
2) Student Complete-Profile Validation Fix
Introduced a dedicated request DTO for student profile completion.
Removed unintended firstName/lastName requirement for this endpoint.
Kept validation for required profile completion fields (birthDate, email).
Why
Students were blocked from completing profile due to validation rules intended for broader user creation/update flows.
Ticket freebies require full backend lifecycle support to ensure selections are saved and reflected in downstream processing/reporting.
Impact
Unblocks student profile completion requests that omit first/last name.
Enables ticket freebie handling throughout cart and order flows.